### PR TITLE
Use dropdown for model selection rather than ROM, allow Plus ROMs on 128K/512K

### DIFF
--- a/core/src/mac/mod.rs
+++ b/core/src/mac/mod.rs
@@ -1,6 +1,7 @@
 use std::fmt::Display;
 
 use hex_literal::hex;
+use serde::{Serialize,Deserialize};
 use sha2::{Digest, Sha256};
 
 use swim::drive::DriveType;
@@ -23,7 +24,7 @@ pub mod swim;
 pub mod via;
 
 /// Differentiation of Macintosh models and their features
-#[derive(Debug, Copy, Clone, PartialOrd, Ord, PartialEq, Eq, strum::EnumIter)]
+#[derive(Debug, Copy, Clone, PartialOrd, Ord, PartialEq, Eq, strum::EnumIter, Serialize, Deserialize)]
 pub enum MacModel {
     /// Macintosh 128K
     Early128K,

--- a/frontend_egui/src/dialogs/modelselect.rs
+++ b/frontend_egui/src/dialogs/modelselect.rs
@@ -38,6 +38,7 @@ pub struct ModelSelectionResult {
     pub memory_size: usize,
     pub main_rom_path: PathBuf,
     pub display_rom_path: Option<PathBuf>,
+    pub selected_model: Option<MacModel>,
 }
 
 impl Default for ModelSelectionDialog {
@@ -173,11 +174,6 @@ impl ModelSelectionDialog {
                 Ok(())
             }
             Some(model) => {
-                bail!(
-                    "ROM is for '{}' but '{}' was selected",
-                    model,
-                    self.selected_model
-                )
                 // Check if attempting to use Plus ROMs on a 128K/512K
                 if (model == MacModel::Plus) & (self.selected_model == MacModel::Early512K)
                     || (self.selected_model == MacModel::Early128K) {
@@ -429,6 +425,7 @@ impl ModelSelectionDialog {
                             } else {
                                 None
                             },
+                            selected_model: Some(self.selected_model),
                         });
                         self.open = false;
                     }

--- a/frontend_egui/src/dialogs/modelselect.rs
+++ b/frontend_egui/src/dialogs/modelselect.rs
@@ -178,6 +178,20 @@ impl ModelSelectionDialog {
                     model,
                     self.selected_model
                 )
+                // Check if attempting to use Plus ROMs on a 128K/512K
+                if (model == MacModel::Plus) & (self.selected_model == MacModel::Early512K)
+                    || (self.selected_model == MacModel::Early128K) {
+                    log::warn!("Using Plus ROM on a {}", self.selected_model);
+                    self.main_rom_valid = true;
+                    Ok(())
+                } else {
+                    bail!(
+                        "ROM is for '{}' but '{}' was selected",
+                        model,
+                        self.selected_model
+                    )
+                }
+
             }
             None => {
                 bail!("Unknown or unsupported ROM file")

--- a/frontend_egui/src/workspace.rs
+++ b/frontend_egui/src/workspace.rs
@@ -6,7 +6,7 @@ use std::path::{Path, PathBuf};
 use anyhow::{Context, Result};
 use eframe::egui;
 use serde::{Deserialize, Serialize};
-
+use snow_core::mac::MacModel;
 use crate::util::relativepath::RelativePath;
 
 /// A workspace representation which contains:
@@ -38,6 +38,9 @@ pub struct Workspace {
 
     /// Last opened Display Card ROM
     display_card_rom_path: Option<RelativePath>,
+    
+    /// Last selected model
+    selected_model: Option<MacModel>,
 
     /// Last loaded disks
     disks: [Option<RelativePath>; 7],
@@ -63,6 +66,7 @@ impl Default for Workspace {
             center_viewport_v: false,
             rom_path: None,
             display_card_rom_path: None,
+            selected_model: None,
             disks: core::array::from_fn(|_| None),
             windows: HashMap::new(),
         }
@@ -145,6 +149,14 @@ impl Workspace {
 
     pub fn get_display_card_rom_path(&self) -> Option<PathBuf> {
         self.display_card_rom_path.clone().map(|d| d.get_absolute())
+    }
+    
+    pub fn set_selected_model(&mut self, m: MacModel) {
+        self.selected_model = Some(m);
+    }
+    
+    pub fn get_selected_model(&self) -> Option<MacModel> {
+        self.selected_model
     }
 
     /// Persists a window location


### PR DESCRIPTION
These changes make it so the model of machine is set by the model selected in the Load ROM dialog, rather than whatever ROM it detects. Otherwise the model selection dialog doesn't seem to serve much purpose other than to prevent you from running with the wrong ROM or prompt you for a video ROM.

This is useful for a few reasons such as:
- Running Macintosh Plus ROMs on a Macintosh 128K or Macintosh 512K (i.e. Macintosh 128Ke/Macintosh 512Ke)
- Running custom/modified ROMs (a future feature perhaps)

Also included is a change to allow a Plus ROM to be a valid ROM when selecting 128K/512K as the model.

I am not highly proficient in Rust so feel free to modify anything.

Example of a Plus ROM running on 512K emulation.
![Screenshot 2025-06-27 at 12 14 52 PM](https://github.com/user-attachments/assets/caea905f-075b-49ae-af3f-154b33a87446)
