### PR TITLE
Force dark mode

### DIFF
--- a/frontend_egui/src/main.rs
+++ b/frontend_egui/src/main.rs
@@ -90,6 +90,9 @@ fn main() -> eframe::Result {
         "Snow",
         options,
         Box::new(|cc| {
+            // Force dark theme as UI elements and colors are not light-friendly (yet)
+            cc.egui_ctx.set_theme(egui::Theme::Dark);
+
             Ok(Box::new(SnowGui::new(
                 cc,
                 r,


### PR DESCRIPTION
UI elements and colors are not suited for light mode yet. Force dark mode for now.

Fixes #42