### PR TITLE
Fix trace/interrupt request exception processing order

### DIFF
--- a/core/src/cpu_m68k/cpu.rs
+++ b/core/src/cpu_m68k/cpu.rs
@@ -404,9 +404,9 @@ where
         // Flag exceptions before executing the instruction to act on them later
         let trace_exception = self.regs.sr.trace() && !self.trace_mask;
         let irq_exception = match self.bus.get_irq() {
-            Some(7) => true,
-            Some(level) => self.regs.sr.int_prio_mask() < level,
-            _ => false,
+            Some(7) => 7,
+            Some(level) if level > self.regs.sr.int_prio_mask() => level,
+            _ => 0,
         };
 
         // Start of instruction execution
@@ -500,8 +500,8 @@ where
         }
 
         // Check pending interrupts
-        if irq_exception {
-            let level = self.bus.get_irq().unwrap();
+        if irq_exception != 0 {
+            let level = irq_exception;
             if self
                 .breakpoints
                 .contains(&Breakpoint::InterruptLevel(level))


### PR DESCRIPTION
This corrects the order of exception processing for trace and interrupt request handling. 
Prior to this the trace exception does not work properly because it is serviced before the current instruction completes, making it so the processor never advances to the next instruction and it gets stuck in a loop.
The interrupt request exception was also being handled in the wrong order, it should be after the current instruction executes, and trace exception processing should happen before interrupt.

With the changes the basic sequence looks like this:
1. Check for interrupt request/trace bit before executing the instruction and flag for later
2. Execute the instruction
3. If the trace flag was set earlier, service the trace exception
4. If the interrupt request flag was set earlier, service the interrupt request

Notably servicing the Trace exception must happen after the instruction has executed, but the check for the trace bit must happen before. Otherwise when `rte` restores the status register the trace bit will be set again, meaning if the check is performed after the instruction executes it will loop back into trace exception again.


Notes from the the 68000 manual:

> Trace and interrupt exceptions allow the current instruction to execute
to completion, but pre-empt the execution of the next instruction by forcing exception
processing to occur.

> if an interrupt request occurs during the execution of an
instruction while the T bit is asserted, the trace exception has priority and is processed
first. Before instruction execution resumes, however, the interrupt exception is also
processed, and instruction processing finally commences in the interrupt handler routine.