### PR TITLE
Add option for framebuffer scaling algorithm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/.idea
 /floppies
 /target
 *.swp

--- a/frontend_egui/src/widgets/framebuffer.rs
+++ b/frontend_egui/src/widgets/framebuffer.rs
@@ -8,13 +8,40 @@ use anyhow::{bail, Result};
 use crossbeam_channel::Receiver;
 use eframe::egui;
 use eframe::egui::Vec2;
+use serde::{Deserialize, Serialize};
 use snow_core::renderer::DisplayBuffer;
+use std::fmt::Display;
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub enum ScalingAlgorithm {
+    Linear,
+    NearestNeighbor,
+}
+
+impl ScalingAlgorithm {
+    fn texture_options(&self) -> egui::TextureOptions {
+        match self {
+            Self::Linear => egui::TextureOptions::LINEAR,
+            Self::NearestNeighbor => egui::TextureOptions::NEAREST,
+        }
+    }
+}
+
+impl Display for ScalingAlgorithm {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Linear => write!(f, "Linear"),
+            Self::NearestNeighbor => write!(f, "Nearest-Neighbor"),
+        }
+    }
+}
 
 pub struct FramebufferWidget {
     frame: Option<DisplayBuffer>,
     frame_recv: Option<Receiver<DisplayBuffer>>,
     viewport_texture: egui::TextureHandle,
     pub scale: f32,
+    pub scaling_algorithm: ScalingAlgorithm,
     display_size: [u16; 2],
 
     response: Option<egui::Response>,
@@ -32,6 +59,7 @@ impl FramebufferWidget {
             ),
             response: None,
             scale: 1.5,
+            scaling_algorithm: ScalingAlgorithm::Linear,
             display_size: [0, 0],
         }
     }
@@ -76,7 +104,7 @@ impl FramebufferWidget {
                                 .map(|c| egui::Color32::from_rgb(c[0], c[1], c[2])),
                         ),
                     },
-                    egui::TextureOptions::LINEAR,
+                    self.scaling_algorithm.texture_options(),
                 );
                 self.frame = Some(frame);
             }

--- a/frontend_egui/src/workspace.rs
+++ b/frontend_egui/src/workspace.rs
@@ -5,6 +5,7 @@ use std::path::{Path, PathBuf};
 
 use crate::emulator::{EmulatorInitArgs, ScsiTarget};
 use crate::util::relativepath::RelativePath;
+use crate::widgets::framebuffer::ScalingAlgorithm;
 use anyhow::{Context, Result};
 use eframe::egui;
 use serde::{Deserialize, Serialize};
@@ -119,6 +120,9 @@ pub struct Workspace {
 
     /// Map Right ALT to Cmd
     pub map_cmd_ralt: bool,
+
+    /// Scaling algorithm in use
+    pub scaling_algorithm: ScalingAlgorithm,
 }
 
 impl Default for Workspace {
@@ -146,6 +150,7 @@ impl Default for Workspace {
             init_args: EmulatorInitArgs::default(),
             model: None,
             map_cmd_ralt: true,
+            scaling_algorithm: ScalingAlgorithm::Linear,
         }
     }
 }


### PR DESCRIPTION
A recent commit changed (f440823190fb0a80b1df74a93723bbe0fd98b904) the framebuffer scaling algorithm from "Nearest-Neighbor" to "Linear". This is a good default, but I found myself missing the ability to use "Nearest-Neighbor" on a high DPI display at 2.0 scaling.

This proposed change adds a new menu option that allows users to change between "Linear" and "Nearest-Neighbor". Saving the workspace will remember which algorithm was in use at the time of save, and restoring a workspace will set the correct scaling algorithm.

<img width="937" height="366" alt="snow_scaling_algorithm" src="https://github.com/user-attachments/assets/fb1b7a9f-6aa9-4944-a0bc-5754fce49147" />

I hope others might find this useful too!