### PR TITLE
Fix test ROM address range accessibility

### DIFF
--- a/core/src/mac/compact/bus.rs
+++ b/core/src/mac/compact/bus.rs
@@ -343,8 +343,13 @@ where
             0x00DF_E1FF..=0x00DF_FFFF => self.swim.read(addr),
             // VIA
             0x00EF_0000..=0x00EF_FFFF => self.via.read(addr),
-            // Test software region (ignore)
-            0x00F8_0000..=0x00F9_FFFF => Some(0xFF),
+            // Test software region / extension ROM
+            0x00F8_0000..=0x00F9_FFFF => Some(
+                *self
+                    .extension_rom
+                    .get((addr - 0xF8_0000) as usize)
+                    .unwrap_or(&0xFF),
+            ),
 
             _ => None,
         };

--- a/core/src/mac/macii/bus.rs
+++ b/core/src/mac/macii/bus.rs
@@ -412,7 +412,9 @@ where
             0xC0_0000..=0xCF_FFFF => 0xFC00_0000 | (addr & 0xF_FFFF),
             0xD0_0000..=0xDF_FFFF => 0xFD00_0000 | (addr & 0xF_FFFF),
             0xE0_0000..=0xEF_FFFF => 0xFE00_0000 | (addr & 0xF_FFFF),
-            0xF0_0000..=0xFF_FFFF => 0x5000_0000 | (addr & 0xF_FFFF),
+            0xF0_0000..=0xF7_FFFF => 0x5000_0000 | (addr & 0xF_FFFF),
+            0xF8_0000..=0xF9_FFFF => 0x5800_0000 | (addr & 0x1_FFFF),
+            0xFA_0000..=0xFF_FFFF => 0x5000_0000 | (addr & 0xF_FFFF),
             _ => unreachable!(),
         }
     }


### PR DESCRIPTION
Fix accesses to the test ROM region when overlay is disabled. Previously the test ROM was only accessible when the overlay was enabled, meaning on most machines the moment you disable the overlay to use RAM you lose your test ROM access, and on the SE you never get test ROM access because the overlay is disabled before the first access to the test ROM.

Also added the test ROM range to the 24 to 32-bit translation table, making the test ROM accessible for 32-bit machines running in 24-bit mode.