### PR TITLE
Fix sporadic panic about total ordering in comparison function

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1163,7 +1163,7 @@ checksum = "0d6ef0072f8a535281e4876be788938b528e9a1d43900b82c2569af7da799125"
 [[package]]
 name = "ecolor"
 version = "0.30.0"
-source = "git+https://github.com/twvd/snow-egui.git?rev=50c4fe34b1de666af33f935c33ed5ff5d050832d#50c4fe34b1de666af33f935c33ed5ff5d050832d"
+source = "git+https://github.com/twvd/snow-egui.git?rev=628a7a4b455f355fafb1d47c9e6870effab96eb5#628a7a4b455f355fafb1d47c9e6870effab96eb5"
 dependencies = [
  "bytemuck",
  "emath",
@@ -1208,7 +1208,7 @@ dependencies = [
 [[package]]
 name = "egui"
 version = "0.30.0"
-source = "git+https://github.com/twvd/snow-egui.git?rev=50c4fe34b1de666af33f935c33ed5ff5d050832d#50c4fe34b1de666af33f935c33ed5ff5d050832d"
+source = "git+https://github.com/twvd/snow-egui.git?rev=628a7a4b455f355fafb1d47c9e6870effab96eb5#628a7a4b455f355fafb1d47c9e6870effab96eb5"
 dependencies = [
  "accesskit",
  "ahash",
@@ -1272,7 +1272,7 @@ dependencies = [
 [[package]]
 name = "egui-winit"
 version = "0.30.0"
-source = "git+https://github.com/twvd/snow-egui.git?rev=50c4fe34b1de666af33f935c33ed5ff5d050832d#50c4fe34b1de666af33f935c33ed5ff5d050832d"
+source = "git+https://github.com/twvd/snow-egui.git?rev=628a7a4b455f355fafb1d47c9e6870effab96eb5#628a7a4b455f355fafb1d47c9e6870effab96eb5"
 dependencies = [
  "accesskit_winit",
  "ahash",
@@ -1352,7 +1352,7 @@ checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 [[package]]
 name = "emath"
 version = "0.30.0"
-source = "git+https://github.com/twvd/snow-egui.git?rev=50c4fe34b1de666af33f935c33ed5ff5d050832d#50c4fe34b1de666af33f935c33ed5ff5d050832d"
+source = "git+https://github.com/twvd/snow-egui.git?rev=628a7a4b455f355fafb1d47c9e6870effab96eb5#628a7a4b455f355fafb1d47c9e6870effab96eb5"
 dependencies = [
  "bytemuck",
 ]
@@ -1431,7 +1431,7 @@ dependencies = [
 [[package]]
 name = "epaint"
 version = "0.30.0"
-source = "git+https://github.com/twvd/snow-egui.git?rev=50c4fe34b1de666af33f935c33ed5ff5d050832d#50c4fe34b1de666af33f935c33ed5ff5d050832d"
+source = "git+https://github.com/twvd/snow-egui.git?rev=628a7a4b455f355fafb1d47c9e6870effab96eb5#628a7a4b455f355fafb1d47c9e6870effab96eb5"
 dependencies = [
  "ab_glyph",
  "ahash",
@@ -1448,7 +1448,7 @@ dependencies = [
 [[package]]
 name = "epaint_default_fonts"
 version = "0.30.0"
-source = "git+https://github.com/twvd/snow-egui.git?rev=50c4fe34b1de666af33f935c33ed5ff5d050832d#50c4fe34b1de666af33f935c33ed5ff5d050832d"
+source = "git+https://github.com/twvd/snow-egui.git?rev=628a7a4b455f355fafb1d47c9e6870effab96eb5#628a7a4b455f355fafb1d47c9e6870effab96eb5"
 
 [[package]]
 name = "equivalent"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,10 +30,10 @@ opt-level = 3
 debug = true
 
 [patch.crates-io]
-ecolor = { git = "https://github.com/twvd/snow-egui.git", rev = "50c4fe34b1de666af33f935c33ed5ff5d050832d"}
-emath = { git = "https://github.com/twvd/snow-egui.git", rev = "50c4fe34b1de666af33f935c33ed5ff5d050832d"}
-epaint = { git = "https://github.com/twvd/snow-egui.git", rev = "50c4fe34b1de666af33f935c33ed5ff5d050832d"}
-egui = { git = "https://github.com/twvd/snow-egui.git", rev = "50c4fe34b1de666af33f935c33ed5ff5d050832d"}
-egui-file-dialog = { git = "https://github.com/twvd/snow-egui-file-dialog.git", rev = "7504d855c587129b36092cea818fafd2153a311b" }
-egui-winit = { git = "https://github.com/twvd/snow-egui.git", rev = "50c4fe34b1de666af33f935c33ed5ff5d050832d"}
+ecolor = { git = "https://github.com/twvd/snow-egui.git", rev = "628a7a4b455f355fafb1d47c9e6870effab96eb5"}
+emath = { git = "https://github.com/twvd/snow-egui.git", rev = "628a7a4b455f355fafb1d47c9e6870effab96eb5"}
+epaint = { git = "https://github.com/twvd/snow-egui.git", rev = "628a7a4b455f355fafb1d47c9e6870effab96eb5"}
+egui = { git = "https://github.com/twvd/snow-egui.git", rev = "628a7a4b455f355fafb1d47c9e6870effab96eb5"}
+egui-winit = { git = "https://github.com/twvd/snow-egui.git", rev = "628a7a4b455f355fafb1d47c9e6870effab96eb5"}
 
+egui-file-dialog = { git = "https://github.com/twvd/snow-egui-file-dialog.git", rev = "7504d855c587129b36092cea818fafd2153a311b" }


### PR DESCRIPTION
This happened sporadically when vigorously navigating the menu's and is caused by an issue in egui 0.30 (fixed in 0.31), triggered by a change in Rust 1.81:
https://blog.rust-lang.org/2024/09/05/Rust-1.81.0/#new-sort-implementations

See upstream PR: emilk/egui#5569

This commit bumps Snow's egui fork to a version with the fix cherry picked.