### PR TITLE
init: BlueSCSI Toolbox v0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /.idea
 /floppies
 /target
+/shared
 *.swp
 *.swo
 *.rom

--- a/core/src/emulator/comm.rs
+++ b/core/src/emulator/comm.rs
@@ -69,6 +69,7 @@ pub enum EmulatorCommand {
     SetPeripheralDebug(bool),
     SccReceiveData(SccCh, Vec<u8>),
     SetSystrapHistory(bool),
+    SetSharedDir(Option<PathBuf>),
     #[cfg(feature = "savestates")]
     SaveState(PathBuf, Option<Vec<u8>>),
 }

--- a/core/src/emulator/mod.rs
+++ b/core/src/emulator/mod.rs
@@ -350,16 +350,7 @@ impl Emulator {
             }
         };
 
-        let s_dir = shared_dir.or_else(|| {
-            let path = PathBuf::from("shared");
-            if path.exists() {
-                Some(path)
-            } else {
-                debug!("No shared directory set, sharing will be disabled");
-                None
-            }
-        });
-        config.scsi_mut().set_shared_dir(s_dir);
+        config.scsi_mut().set_shared_dir(shared_dir);
         config.cpu_reset()?;
 
         let mut emu = Self {

--- a/core/src/emulator/mod.rs
+++ b/core/src/emulator/mod.rs
@@ -9,9 +9,10 @@ use snow_floppy::Floppy;
 use std::collections::VecDeque;
 #[cfg(feature = "savestates")]
 use std::fs::File;
+use std::fs;
 #[cfg(feature = "savestates")]
 use std::io::Seek;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::thread;
 use std::time::{Duration, Instant};
 use strum::IntoEnumIterator;
@@ -347,6 +348,12 @@ impl Emulator {
                 }
             }
         };
+
+        let shared_dir = PathBuf::from("shared");
+        if !shared_dir.exists() {
+            fs::create_dir(&shared_dir)?;
+        }
+        config.scsi_mut().set_shared_dir(shared_dir);
 
         config.cpu_reset()?;
 

--- a/core/src/mac/scsi/controller.rs
+++ b/core/src/mac/scsi/controller.rs
@@ -302,6 +302,9 @@ impl ScsiController {
                 self.assert_req();
             }
             ScsiBusPhase::DataIn => {
+                if self.responsebuf.is_empty() {
+                    return self.set_phase(ScsiBusPhase::Status);
+                }
                 self.reg_csr.set_bsy(true);
                 self.reg_csr.set_cd(false);
                 self.reg_csr.set_io(true);

--- a/core/src/mac/scsi/controller.rs
+++ b/core/src/mac/scsi/controller.rs
@@ -202,8 +202,8 @@ impl ScsiController {
         self.targets[id].as_ref().map(|t| t.target_type())
     }
 
-    pub fn set_shared_dir(&mut self, path: PathBuf) {
-        self.toolbox = BlueSCSI::new(Some(path));
+    pub fn set_shared_dir(&mut self, path: Option<PathBuf>) {
+        self.toolbox = BlueSCSI::new(path);
     }
 
     pub fn new() -> Self {

--- a/core/src/mac/scsi/disk.rs
+++ b/core/src/mac/scsi/disk.rs
@@ -258,6 +258,14 @@ impl ScsiTarget for ScsiTargetDisk {
 
                 Some(result)
             }
+            0x31 => {
+                // BlueSCSI vendor page
+                let mut result = vec![0; 42];
+                // A joke based on https://www.folklore.org/Stolen_From_Apple.html
+                result[0..42].copy_from_slice(b"BlueSCSI is the BEST STOLEN FROM BLUESCSI\x00");
+
+                Some(result)
+            }
             _ => None,
         }
     }

--- a/core/src/mac/scsi/mod.rs
+++ b/core/src/mac/scsi/mod.rs
@@ -4,6 +4,7 @@ pub mod cdrom;
 pub mod controller;
 pub mod disk;
 pub mod target;
+pub mod toolbox;
 
 pub const STATUS_GOOD: u8 = 0;
 pub const STATUS_CHECK_CONDITION: u8 = 2;
@@ -54,6 +55,8 @@ const fn scsi_cmd_len(cmdnum: u8) -> Option<usize> {
         | 0x3C
         // READ TOC
         | 0x43
+        // BlueSCSI Toolbox commands
+        | 0xD0..=0xD9
         => Some(10),
         _ => {
             None

--- a/core/src/mac/scsi/toolbox.rs
+++ b/core/src/mac/scsi/toolbox.rs
@@ -1,0 +1,237 @@
+//! BlueSCSI Toolbox vendor-specific commands
+//! This is an implementation of th BlueSCSI Toolbox v0 commands suitable for the Snow emulator.
+//! CD switching is not implemented as the emulator can do this easily via the UI.
+//! API Docs: https://github.com/BlueSCSI/BlueSCSI-v2/wiki/Toolbox-Developer-Docs
+//! Note: THere are some limitations due to RAM/Flash space on the BlueSCSI that are not a concern
+//!  on a more powerful machines. We would like to use Snow as a test/dev for the BlueSCSI toolbox.
+//!  We hope to prototype v1 of the Toolbox API in Snow first, then port it back to BlueSCSI's Pico.
+
+use std::fs::{self, File};
+use std::io::{Read, Seek, SeekFrom, Write};
+use std::path::PathBuf;
+
+use log::*;
+
+use super::{ScsiCmdResult, STATUS_CHECK_CONDITION, STATUS_GOOD};
+
+const MAX_FILE_PATH: usize = 32; // Max Macintosh File name length
+
+#[derive(Default)]
+pub struct BlueSCSI {
+    shared_dir: Option<PathBuf>,
+    file: Option<File>,
+}
+
+impl BlueSCSI {
+    pub fn new(shared_dir: Option<PathBuf>) -> Self {
+        Self {
+            shared_dir,
+            file: None,
+        }
+    }
+
+    pub(crate) fn handle_command(
+        &mut self,
+        cmd: &[u8],
+        outdata: Option<&[u8]>,
+        debug_enabled: &mut bool,
+    ) -> ScsiCmdResult {
+        if *debug_enabled {
+            debug!("BlueSCSI command: {:02X?}", cmd);
+        }
+        match cmd[0] {
+            0xD0 => self.list_files(),
+            0xD1 => self.get_file(cmd),
+            0xD2 => self.count_files(),
+            0xD3 => self.send_file_prep(outdata),
+            0xD4 => self.send_file_10(cmd, outdata),
+            0xD5 => self.send_file_end(),
+            0xD6 => self.toggle_debug(cmd, debug_enabled),
+            _ => {
+                error!("Unknown BlueSCSI command: {:02X}", cmd[0]);
+                ScsiCmdResult::Status(STATUS_CHECK_CONDITION)
+            }
+        }
+    }
+
+    fn toggle_debug(&mut self, cmd: &[u8], debug_enabled: &mut bool) -> ScsiCmdResult {
+        if cmd[1] == 0 {
+            *debug_enabled = cmd[2] != 0;
+            debug!("Set BlueSCSI debug logs to: {}", *debug_enabled);
+            ScsiCmdResult::Status(STATUS_GOOD)
+        } else {
+            debug!("Get BlueSCSI debug logs state: {}", *debug_enabled);
+            ScsiCmdResult::DataIn(vec![*debug_enabled as u8])
+        }
+    }
+
+    fn count_files(&self) -> ScsiCmdResult {
+        let Some(shared_dir) = &self.shared_dir else {
+            return ScsiCmdResult::Status(STATUS_CHECK_CONDITION);
+        };
+        let Ok(entries) = fs::read_dir(shared_dir) else {
+            return ScsiCmdResult::Status(STATUS_CHECK_CONDITION);
+        };
+
+        let mut file_count = 0;
+        for entry in entries {
+            if let Ok(entry) = entry {
+                if let Some(name) = entry.file_name().to_str() {
+                    if !name.starts_with('.') {
+                        file_count += 1;
+                    }
+                }
+            }
+        }
+        ScsiCmdResult::DataIn(vec![file_count as u8])
+    }
+
+    fn list_files(&self) -> ScsiCmdResult {
+        let Some(shared_dir) = &self.shared_dir else {
+            return ScsiCmdResult::Status(STATUS_CHECK_CONDITION);
+        };
+        const ENTRY_SIZE: usize = 40;
+        let Ok(entries) = fs::read_dir(shared_dir) else {
+            return ScsiCmdResult::Status(STATUS_CHECK_CONDITION);
+        };
+
+        let mut data = Vec::new();
+        let mut index = 0;
+
+        for entry in entries {
+            if let Ok(entry) = entry {
+                if let Some(name_str) = entry.file_name().to_str() {
+                    if name_str.starts_with('.') {
+                        continue;
+                    }
+
+                    let mut file_entry = vec![0; ENTRY_SIZE];
+                    let metadata = entry.metadata().ok();
+                    let is_dir = metadata.as_ref().map(|m| m.is_dir()).unwrap_or(false);
+                    let size = metadata.as_ref().map(|m| m.len()).unwrap_or(0);
+
+                    file_entry[0] = index;
+                    file_entry[1] = if is_dir { 0x00 } else { 0x01 };
+
+                    let name_bytes = name_str.as_bytes();
+                    let len = name_bytes.len().min(MAX_FILE_PATH);
+                    file_entry[2..2 + len].copy_from_slice(&name_bytes[..len]);
+
+                    file_entry[36..40].copy_from_slice(&(size as u32).to_be_bytes());
+
+                    data.extend_from_slice(&file_entry);
+                    index += 1;
+                }
+            }
+        }
+        ScsiCmdResult::DataIn(data)
+    }
+
+    fn get_file_from_index(&self, index: u8) -> Option<PathBuf> {
+        let Some(shared_dir) = &self.shared_dir else {
+            return None;
+        };
+        let Ok(entries) = fs::read_dir(shared_dir) else {
+            return None;
+        };
+        let mut count = 0;
+        for entry in entries {
+            if let Ok(entry) = entry {
+                if let Some(name) = entry.file_name().to_str() {
+                    if !name.starts_with('.') {
+                        if count == index {
+                            return Some(entry.path());
+                        }
+                        count += 1;
+                    }
+                }
+            }
+        }
+        None
+    }
+
+    fn get_file(&mut self, cmd: &[u8]) -> ScsiCmdResult {
+        let index = cmd[1];
+        let offset = u32::from_be_bytes(cmd[2..6].try_into().unwrap()) as u64;
+        let block_size = 4096;
+
+        if offset == 0 {
+            let path = self.get_file_from_index(index);
+            if let Some(path) = path {
+                self.file = File::open(path).ok();
+            }
+        }
+
+        if let Some(file) = &mut self.file {
+            let mut buffer = vec![0; block_size];
+            if file
+                .seek(SeekFrom::Start(offset * block_size as u64))
+                .is_ok()
+            {
+                if let Ok(bytes_read) = file.read(&mut buffer) {
+                    buffer.truncate(bytes_read);
+                    if bytes_read == 0 {
+                        self.file = None;
+                    }
+                    return ScsiCmdResult::DataIn(buffer);
+                }
+            }
+        }
+        ScsiCmdResult::Status(STATUS_CHECK_CONDITION)
+    }
+
+    fn send_file_prep(&mut self, outdata: Option<&[u8]>) -> ScsiCmdResult {
+        let Some(shared_dir) = &self.shared_dir else {
+            return ScsiCmdResult::Status(STATUS_CHECK_CONDITION);
+        };
+        if let Some(data) = outdata {
+            if let Some(pos) = data.iter().position(|&b| b == 0) {
+                if let Ok(name) = std::str::from_utf8(&data[..pos]) {
+                    let path = shared_dir.join(name);
+                    match File::create(path) {
+                        Ok(f) => {
+                            self.file = Some(f);
+                            return ScsiCmdResult::Status(STATUS_GOOD);
+                        }
+                        Err(e) => {
+                            error!("Failed to create file: {}", e);
+                        }
+                    }
+                }
+            }
+        } else {
+            // Expecting data out
+            return ScsiCmdResult::DataOut(32 + 1);
+        }
+        ScsiCmdResult::Status(STATUS_CHECK_CONDITION)
+    }
+
+    fn send_file_10(&mut self, cmd: &[u8], outdata: Option<&[u8]>) -> ScsiCmdResult {
+        let bytes_sent = u16::from_be_bytes(cmd[1..3].try_into().unwrap());
+        let mut offset_bytes = [0u8; 4];
+        offset_bytes[1..4].copy_from_slice(&cmd[3..6]);
+        let offset = u32::from_be_bytes(offset_bytes);
+
+        if let Some(file) = &mut self.file {
+            if let Some(data) = outdata {
+                if file.seek(SeekFrom::Start(offset as u64 * 512)).is_ok() {
+                    if file.write_all(&data[..bytes_sent as usize]).is_ok() {
+                        return ScsiCmdResult::Status(STATUS_GOOD);
+                    }
+                }
+            } else {
+                return ScsiCmdResult::DataOut(bytes_sent as usize);
+            }
+        }
+        ScsiCmdResult::Status(STATUS_CHECK_CONDITION)
+    }
+
+    fn send_file_end(&mut self) -> ScsiCmdResult {
+        if let Some(file) = self.file.take() {
+            if file.sync_all().is_ok() {
+                return ScsiCmdResult::Status(STATUS_GOOD);
+            }
+        }
+        ScsiCmdResult::Status(STATUS_CHECK_CONDITION)
+    }
+}

--- a/frontend_egui/src/app.rs
+++ b/frontend_egui/src/app.rs
@@ -686,12 +686,12 @@ impl SnowGui {
                 ui.menu_button("File sharing", |ui| {
                     ui.set_min_width(Self::SUBMENU_WIDTH + 100.0);
                     ui.label("Shared folder (for BlueSCSI toolbox):");
-                    let shared_dir_str = self
+                    let mut shared_dir_str = self
                         .workspace
                         .get_shared_dir()
                         .map(|p| p.to_string_lossy().to_string())
                         .unwrap_or_default();
-                    ui.text_edit_singleline(&mut shared_dir_str.clone());
+                    ui.text_edit_singleline(&mut shared_dir_str);
                     if ui.button("Select folder...").clicked() {
                         self.shared_dir_dialog.pick_directory();
                         ui.close_menu();

--- a/frontend_egui/src/dialogs/modelselect.rs
+++ b/frontend_egui/src/dialogs/modelselect.rs
@@ -7,6 +7,7 @@ use eframe::egui;
 use egui_file_dialog::FileDialog;
 use sha2::{Digest, Sha256};
 use snow_core::emulator::MouseMode;
+use snow_core::mac::swim::drive::DriveType;
 use snow_core::mac::{MacModel, MacMonitor};
 use strum::IntoEnumIterator;
 
@@ -563,7 +564,25 @@ impl ModelSelectionDialog {
                             } else {
                                 Some(PathBuf::from(&self.extension_rom_path))
                             },
-                            init_args: self.init_args.clone(),
+                            init_args: EmulatorInitArgs {
+                                monitor: if self.display_rom_required {
+                                    Some(self.selected_monitor)
+                                } else {
+                                    None
+                                },
+                                // Deprecated
+                                mouse_disabled: None,
+                                override_fdd_type: if matches!(
+                                    self.selected_model,
+                                    MacModel::Early128K | MacModel::Early512K
+                                ) && self.early_800k
+                                {
+                                    Some(DriveType::GCR800KPWM)
+                                } else {
+                                    None
+                                },
+                                ..self.init_args
+                            },
                         });
                         self.open = false;
                     }

--- a/frontend_egui/src/dialogs/modelselect.rs
+++ b/frontend_egui/src/dialogs/modelselect.rs
@@ -7,7 +7,6 @@ use eframe::egui;
 use egui_file_dialog::FileDialog;
 use sha2::{Digest, Sha256};
 use snow_core::emulator::MouseMode;
-use snow_core::mac::swim::drive::DriveType;
 use snow_core::mac::{MacModel, MacMonitor};
 use strum::IntoEnumIterator;
 

--- a/frontend_egui/src/dialogs/modelselect.rs
+++ b/frontend_egui/src/dialogs/modelselect.rs
@@ -564,25 +564,7 @@ impl ModelSelectionDialog {
                             } else {
                                 Some(PathBuf::from(&self.extension_rom_path))
                             },
-                            init_args: EmulatorInitArgs {
-                                monitor: if self.display_rom_required {
-                                    Some(self.selected_monitor)
-                                } else {
-                                    None
-                                },
-                                // Deprecated
-                                mouse_disabled: None,
-                                override_fdd_type: if matches!(
-                                    self.selected_model,
-                                    MacModel::Early128K | MacModel::Early512K
-                                ) && self.early_800k
-                                {
-                                    Some(DriveType::GCR800KPWM)
-                                } else {
-                                    None
-                                },
-                                ..self.init_args
-                            },
+                            init_args: self.init_args.clone(),
                         });
                         self.open = false;
                     }

--- a/frontend_egui/src/emulator.rs
+++ b/frontend_egui/src/emulator.rs
@@ -140,6 +140,7 @@ impl EmulatorState {
         pram: Option<&Path>,
         args: &EmulatorInitArgs,
         model: Option<MacModel>,
+        shared_dir: Option<PathBuf>,
     ) -> Result<EmulatorInitResult> {
         let rom = std::fs::read(filename)?;
         let display_rom = if let Some(filename) = display_rom_path {
@@ -160,6 +161,7 @@ impl EmulatorState {
             pram,
             args,
             model,
+            shared_dir,
         )
     }
 
@@ -174,6 +176,7 @@ impl EmulatorState {
         pram: Option<&Path>,
         args: &EmulatorInitArgs,
         model: Option<MacModel>,
+        shared_dir: Option<PathBuf>,
     ) -> Result<EmulatorInitResult> {
         // Terminate running emulator (if any)
         self.deinit();
@@ -214,6 +217,7 @@ impl EmulatorState {
             args.ram_size,
             args.override_fdd_type,
             args.pmmu_enabled,
+            shared_dir,
         )?;
 
         let cmd = emulator.create_cmd_sender();
@@ -990,5 +994,12 @@ impl EmulatorState {
         sender
             .send(EmulatorCommand::SaveState(p.to_path_buf(), screenshot))
             .unwrap();
+    }
+
+    pub fn set_shared_dir(&self, path: Option<PathBuf>) {
+        let Some(ref sender) = self.cmdsender else {
+            return;
+        };
+        sender.send(EmulatorCommand::SetSharedDir(path)).unwrap();
     }
 }

--- a/frontend_egui/src/workspace.rs
+++ b/frontend_egui/src/workspace.rs
@@ -126,6 +126,9 @@ pub struct Workspace {
 
     /// Pause emulator after loading a state/state file
     pub pause_on_state_load: bool,
+
+    /// Shared directory for BlueSCSI toolbox
+    shared_dir: Option<RelativePath>,
 }
 
 impl Default for Workspace {
@@ -155,6 +158,7 @@ impl Default for Workspace {
             map_cmd_ralt: true,
             scaling_algorithm: ScalingAlgorithm::Linear,
             pause_on_state_load: false,
+            shared_dir: None,
         }
     }
 }
@@ -191,6 +195,9 @@ impl Workspace {
         if let Some(p) = result.extension_rom_path.as_mut() {
             p.after_deserialize(parent)?;
         }
+        if let Some(p) = result.shared_dir.as_mut() {
+            p.after_deserialize(parent)?;
+        }
         for d in &mut result.scsi_targets {
             match d {
                 WorkspaceScsiTarget::Disk(ref mut p) => p.after_deserialize(parent)?,
@@ -223,6 +230,9 @@ impl Workspace {
             p.before_serialize(parent)?;
         }
         if let Some(p) = self.extension_rom_path.as_mut() {
+            p.before_serialize(parent)?;
+        }
+        if let Some(p) = self.shared_dir.as_mut() {
             p.before_serialize(parent)?;
         }
         // disks is deprecated
@@ -275,6 +285,14 @@ impl Workspace {
 
     pub fn get_pram_path(&self) -> Option<PathBuf> {
         self.pram_path.clone().map(|d| d.get_absolute())
+    }
+
+    pub fn set_shared_dir(&mut self, p: Option<&Path>) {
+        self.shared_dir = p.map(RelativePath::from_absolute);
+    }
+
+    pub fn get_shared_dir(&self) -> Option<PathBuf> {
+        self.shared_dir.clone().map(|d| d.get_absolute())
     }
 
     /// Persists a window location


### PR DESCRIPTION
This PR adds the ability for the emulated Mac to share files to and from with the host machine (think ImportFi/ExportFi on minivmac) using the BlueSCSI Toolbox API v0. This API is optimized for a micro controller so some limitations there will not apply here. Though I would like to keep the API compatible between the two for ease of development.

Note this uses the SCSI bus so will not work on emulated Macs without SCSI (128/512k).

<img width="810" height="630" alt="image" src="https://github.com/user-attachments/assets/6a99e494-8f0b-4328-a1e6-dda76a59c281" />

TODO: 
- [ ] Created a branded Snow version of the BlueSCSI Toolbox Mac app that can be embedded in a 400k disk for ease of use in Snowemu
- [ ] Test on Win/macOS (only test on Linux so far)

Future:
* Allow Drag and Drop to work while the BlueSCSI Toolbox app or Extension is running.
* Implement v1 of the BlueSCSI Toolbox API.

Not done:
* CD Switching app - this can be done easily in Snow's UI.