### PR TITLE
doc (BUILDING.md): add Fedora install guide, and build from source without running guide

### DIFF
--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -32,7 +32,7 @@ sudo dnf install sdl2-compat-devel pkgconf-pkg-config
 To build after checking out the source, simply run:
 
 ```
-cargo build
+cargo build -r
 ```
 
 This will place the `snow_frontend_egui` binary into `target/release`.


### PR DESCRIPTION
This is useful for people who do not want to run the program right away, and for packaging.