### PR TITLE
Remove built and git2 from runtime dependencies

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -29,7 +29,6 @@ workspace = true
 anyhow = { version = "1.0.86", features = ["backtrace"] }
 arrayvec = { version = "0.7.4", features = ["serde"] }
 biquad = "0.4.2"
-built = { version = "0.8.0", features = ["chrono", "git2"] }
 chrono = "0.4.38"
 crc = { version = "3.2.1", optional = true }
 crossbeam = "0.8.4"


### PR DESCRIPTION
It's not actually needed (we only need it as a build dependency). Generally good hygiene, and also helps with the Emscripten build (`git2` does not build for that target).