### PR TITLE
Add more flexibilty in how SCSI disk images are loaded

### DIFF
--- a/core/src/emulator/mod.rs
+++ b/core/src/emulator/mod.rs
@@ -45,6 +45,7 @@ use crate::cpu_m68k::regs::{Register, RegisterFile};
 use crate::emulator::comm::{EmulatorSpeed, UserMessageType};
 use crate::mac::rtc::Rtc;
 use crate::mac::scsi::controller::ScsiController;
+use crate::mac::scsi::disk_image::DiskImage;
 use crate::mac::swim::Swim;
 use comm::{
     Breakpoint, EmulatorCommand, EmulatorCommandSender, EmulatorEvent, EmulatorEventReceiver,
@@ -678,6 +679,14 @@ impl Emulator {
 
     pub fn load_hdd_image(&mut self, filename: &Path, scsi_id: usize) -> Result<()> {
         self.config.scsi_mut().attach_hdd_at(filename, scsi_id)
+    }
+
+    pub fn attach_disk_image_at(
+        &mut self,
+        image: Box<dyn DiskImage>,
+        scsi_id: usize,
+    ) -> Result<()> {
+        self.config.scsi_mut().attach_disk_image_at(image, scsi_id)
     }
 
     fn user_error(&self, msg: &str) {

--- a/core/src/mac/scsi/controller.rs
+++ b/core/src/mac/scsi/controller.rs
@@ -18,6 +18,7 @@ use crate::dbgprop_byte;
 use crate::debuggable::Debuggable;
 use crate::mac::scsi::cdrom::ScsiTargetCdrom;
 use crate::mac::scsi::disk::ScsiTargetDisk;
+use crate::mac::scsi::disk_image::DiskImage;
 #[cfg(feature = "ethernet")]
 use crate::mac::scsi::ethernet::ScsiTargetEthernet;
 use crate::mac::scsi::scsi_cmd_len;
@@ -240,6 +241,19 @@ impl ScsiController {
             bail!("File {} does not exist", filename.to_string_lossy());
         }
         self.targets[scsi_id] = Some(Box::new(ScsiTargetDisk::load_disk(filename)?));
+        Ok(())
+    }
+
+    /// Attaches a disk backed by a custom disk image at the given SCSI ID.
+    pub(crate) fn attach_disk_image_at(
+        &mut self,
+        image: Box<dyn DiskImage>,
+        scsi_id: usize,
+    ) -> Result<()> {
+        if scsi_id >= Self::MAX_TARGETS {
+            bail!("SCSI ID out of range: {}", scsi_id);
+        }
+        self.targets[scsi_id] = Some(Box::new(ScsiTargetDisk::new(image)));
         Ok(())
     }
 

--- a/core/src/mac/scsi/disk_image.rs
+++ b/core/src/mac/scsi/disk_image.rs
@@ -1,0 +1,147 @@
+//! SCSI disk image abstraction
+
+use anyhow::{bail, Context, Result};
+#[cfg(feature = "mmap")]
+use memmap2::MmapMut;
+use std::path::{Path, PathBuf};
+
+pub trait DiskImage: Send {
+    fn byte_len(&self) -> usize;
+    fn read_bytes(&self, offset: usize, length: usize) -> Vec<u8>;
+    fn write_bytes(&mut self, offset: usize, data: &[u8]);
+    fn media_bytes(&self) -> Option<&[u8]>;
+    fn image_path(&self) -> Option<&Path>;
+    fn branch_media(&mut self, _path: &Path) -> Result<()> {
+        bail!("branch_media not supported");
+    }
+}
+
+pub(crate) struct FileDiskImage {
+    /// Disk contents
+    #[cfg(feature = "mmap")]
+    disk: MmapMut,
+
+    #[cfg(not(feature = "mmap"))]
+    disk: Vec<u8>,
+
+    /// Path where the original image resides
+    path: PathBuf,
+
+    /// Only used when mmap is enabled
+    #[allow(dead_code)]
+    block_size: usize,
+}
+
+impl FileDiskImage {
+    pub(super) fn open(filename: &Path, block_size: usize) -> Result<Self> {
+        if !filename.exists() {
+            bail!("File not found: {}", filename.display());
+        }
+
+        #[cfg(feature = "mmap")]
+        let disk = Self::mmap_file(filename, block_size)?;
+
+        #[cfg(not(feature = "mmap"))]
+        let disk = {
+            use std::fs;
+
+            let disk = fs::read(filename)
+                .with_context(|| format!("Failed to open file {}", filename.display()))?;
+            if !disk.len().is_multiple_of(block_size) {
+                bail!(
+                    "Cannot load disk image {}: not multiple of {}",
+                    filename.display(),
+                    block_size
+                );
+            }
+            disk
+        };
+
+        Ok(Self {
+            block_size,
+            disk,
+            path: filename.to_path_buf(),
+        })
+    }
+
+    #[cfg(feature = "mmap")]
+    fn mmap_file(filename: &Path, block_size: usize) -> Result<MmapMut> {
+        use fs2::FileExt;
+        use std::fs::OpenOptions;
+        use std::io::{Seek, SeekFrom};
+
+        if !filename.exists() {
+            bail!("File not found: {}", filename.display());
+        }
+        let mut f = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(filename)
+            .with_context(|| format!("Failed to open {}", filename.display()))?;
+        let file_size = f.seek(SeekFrom::End(0))? as usize;
+        f.seek(SeekFrom::Start(0))?;
+        if !file_size.is_multiple_of(block_size) {
+            bail!(
+                "Cannot load disk image {}: not multiple of {}",
+                filename.display(),
+                block_size
+            );
+        }
+
+        f.try_lock_exclusive()
+            .with_context(|| format!("Failed to lock {}", filename.display()))?;
+        let mmapped = unsafe {
+            use memmap2::MmapOptions;
+
+            MmapOptions::new()
+                .len(file_size)
+                .map_mut(&f)
+                .with_context(|| format!("Failed to mmap file {}", filename.display()))?
+        };
+        Ok(mmapped)
+    }
+}
+
+impl DiskImage for FileDiskImage {
+    fn byte_len(&self) -> usize {
+        self.disk.len()
+    }
+
+    fn read_bytes(&self, offset: usize, length: usize) -> Vec<u8> {
+        self.disk[offset..(offset + length)].to_vec()
+    }
+
+    fn write_bytes(&mut self, offset: usize, data: &[u8]) {
+        self.disk[offset..(offset + data.len())].copy_from_slice(data);
+    }
+
+    fn media_bytes(&self) -> Option<&[u8]> {
+        Some(&self.disk)
+    }
+
+    fn image_path(&self) -> Option<&Path> {
+        Some(self.path.as_ref())
+    }
+
+    fn branch_media(&mut self, path: &Path) -> Result<()> {
+        #[cfg(feature = "mmap")]
+        {
+            use std::fs::File;
+            use std::io::Write;
+
+            // Create a fresh disk file
+            {
+                let mut f = File::create(path)?;
+                f.write_all(&self.disk)?;
+            }
+            self.disk = Self::mmap_file(path, self.block_size)?;
+            self.path = path.to_path_buf();
+            Ok(())
+        }
+        #[cfg(not(feature = "mmap"))]
+        {
+            let _ = path;
+            bail!("Requires 'mmap' feature");
+        }
+    }
+}

--- a/core/src/mac/scsi/mod.rs
+++ b/core/src/mac/scsi/mod.rs
@@ -3,6 +3,7 @@
 pub mod cdrom;
 pub mod controller;
 pub mod disk;
+pub mod disk_image;
 #[cfg(feature = "ethernet")]
 pub mod ethernet;
 pub mod target;


### PR DESCRIPTION
Instead of assuming that they're always backed by a file on disk that can be read into a `Vec<u8>`, introduce a more generic `DiskImage` trait can serve as the backend of a `ScsiTargetDisk`. The existing file-backed implementation is kept as `FileDiskImage`.

Meant to allow more flexibility in the Infinite Mac port, where disk images are loaded via JS APIs, but also seems generally useful (e.g. if you want to back a SCSI disk image by something that automatically adds a device image header on raw HFS partitions, or something that is backed by a compressed file format).