### PR TITLE
Add more flexibility in how audio data is sent

### DIFF
--- a/core/src/emulator/mod.rs
+++ b/core/src/emulator/mod.rs
@@ -31,7 +31,7 @@ use crate::mac::serial_bridge::{SccBridge, SerialBridgeStatus};
 use crate::mac::swim::drive::DriveType;
 use crate::mac::{ExtraROMs, MacModel, MacMonitor};
 use crate::renderer::channel::ChannelRenderer;
-use crate::renderer::AudioReceiver;
+use crate::renderer::AudioSink;
 use crate::renderer::{DisplayBuffer, Renderer};
 use crate::tickable::{Tickable, Ticks};
 use crate::types::Byte;
@@ -190,11 +190,11 @@ dispatch! {
         fn speed(&self) -> EmulatorSpeed { bus.speed }
         fn effective_speed(&self) -> f64 { bus.get_effective_speed() }
         fn debug_properties(&self) -> DebuggableProperties { bus.get_debug_properties() }
-        fn get_audio_channel(&self) -> AudioReceiver { bus.get_audio_channel() }
     }
 
     mutable_calls {
         fn set_speed(&mut self, speed: EmulatorSpeed) -> () { bus.set_speed(speed) }
+        fn set_audio_sink(&mut self, sink: Box<dyn AudioSink>) -> () { bus.set_audio_sink(sink) }
 
         fn cpu_tick(&mut self, ticks: Ticks) -> Result<Ticks> { tick(ticks) }
         fn cpu_set_breakpoint(&mut self, bp: Breakpoint) -> () { set_breakpoint(bp) }
@@ -673,8 +673,8 @@ impl Emulator {
         Ok(())
     }
 
-    pub fn get_audio(&mut self) -> AudioReceiver {
-        self.config.get_audio_channel()
+    pub fn set_audio_sink(&mut self, sink: Box<dyn AudioSink>) {
+        self.config.set_audio_sink(sink);
     }
 
     pub fn load_hdd_image(&mut self, filename: &Path, scsi_id: usize) -> Result<()> {

--- a/core/src/mac/compact/bus.rs
+++ b/core/src/mac/compact/bus.rs
@@ -17,7 +17,7 @@ use crate::mac::swim::drive::DriveType;
 use crate::mac::swim::Swim;
 use crate::mac::via::Via;
 use crate::mac::MacModel;
-use crate::renderer::{AudioReceiver, Renderer};
+use crate::renderer::{AudioSink, Renderer};
 use crate::tickable::{Tickable, Ticks};
 use crate::types::{Byte, LatchingEvent, MouseEvent};
 use crate::util::take_from_accumulator;
@@ -232,8 +232,8 @@ where
         self.via.rtc.effective_speed()
     }
 
-    pub(crate) fn get_audio_channel(&self) -> AudioReceiver {
-        self.audio.receiver.as_ref().unwrap().clone()
+    pub(crate) fn set_audio_sink(&mut self, sink: Box<dyn AudioSink>) {
+        self.audio.set_sink(sink);
     }
 
     fn soundbuf(&mut self) -> &mut [u8] {

--- a/core/src/mac/macii/bus.rs
+++ b/core/src/mac/macii/bus.rs
@@ -18,7 +18,7 @@ use crate::mac::scsi::controller::ScsiController;
 use crate::mac::swim::Swim;
 use crate::mac::via::Via;
 use crate::mac::{MacModel, MacMonitor};
-use crate::renderer::{AudioReceiver, Renderer};
+use crate::renderer::{AudioSink, Renderer};
 use crate::tickable::{Tickable, Ticks};
 use crate::types::{Byte, LatchingEvent, MouseEvent};
 
@@ -274,8 +274,8 @@ where
         self.via1.rtc.effective_speed()
     }
 
-    pub(crate) fn get_audio_channel(&self) -> AudioReceiver {
-        self.asc.receiver.as_ref().unwrap().clone()
+    pub(crate) fn set_audio_sink(&mut self, sink: Box<dyn AudioSink>) {
+        self.asc.set_sink(sink);
     }
 
     #[allow(clippy::needless_pass_by_value)]


### PR DESCRIPTION
The Infinite Mac JavaScript port is single-threaded, and I was running into deadlocks with the `crossbeam_channel`-based approach for moving audio data around. Move it to an `AudioSink` trait with a `ChannelAudioSink` default implementation, but allow it to be overridden if desired.

Hopefully not a big complexity increase, and this also allows a bit more code sharing between the `compact` and `macii` paths.