### PR TITLE
Use DiskImage trait for CD-ROM devices too

### DIFF
--- a/core/src/emulator/mod.rs
+++ b/core/src/emulator/mod.rs
@@ -689,6 +689,14 @@ impl Emulator {
         self.config.scsi_mut().attach_disk_image_at(image, scsi_id)
     }
 
+    pub fn insert_cdrom_image_at(
+        &mut self,
+        image: Box<dyn DiskImage>,
+        scsi_id: usize,
+    ) -> Result<()> {
+        self.config.scsi_mut().insert_cdrom_image_at(image, scsi_id)
+    }
+
     fn user_error(&self, msg: &str) {
         self.event_sender
             .send(EmulatorEvent::UserMessage(

--- a/core/src/mac/scsi/controller.rs
+++ b/core/src/mac/scsi/controller.rs
@@ -262,6 +262,21 @@ impl ScsiController {
         self.targets[scsi_id] = Some(Box::new(ScsiTargetCdrom::default()));
     }
 
+    /// Inserts a CD-ROM with the custom disk image at the given SCSI ID.
+    pub fn insert_cdrom_image_at(
+        &mut self,
+        image: Box<dyn DiskImage>,
+        scsi_id: usize,
+    ) -> Result<()> {
+        if scsi_id >= Self::MAX_TARGETS {
+            bail!("SCSI ID out of range: {}", scsi_id);
+        }
+        let Some(target) = self.targets[scsi_id].as_mut() else {
+            bail!("No target attached at SCSI ID {}", scsi_id);
+        };
+        target.load_image(image)
+    }
+
     /// Attaches an Ethernet adapter at the given SCSI ID
     #[cfg(feature = "ethernet")]
     pub fn attach_ethernet_at(&mut self, scsi_id: usize) {

--- a/core/src/mac/scsi/ethernet.rs
+++ b/core/src/mac/scsi/ethernet.rs
@@ -605,6 +605,13 @@ impl ScsiTarget for ScsiTargetEthernet {
         unreachable!()
     }
 
+    fn load_image(
+        &mut self,
+        _image: Box<dyn crate::mac::scsi::disk_image::DiskImage>,
+    ) -> Result<()> {
+        unreachable!()
+    }
+
     fn branch_media(&mut self, _path: &Path) -> Result<()> {
         unreachable!()
     }

--- a/core/src/mac/scsi/target.rs
+++ b/core/src/mac/scsi/target.rs
@@ -5,6 +5,7 @@ use std::path::Path;
 use anyhow::Result;
 
 use crate::debuggable::Debuggable;
+use crate::mac::scsi::disk_image::DiskImage;
 use crate::mac::scsi::{
     ScsiCmdResult, ASC_INVALID_FIELD_IN_CDB, ASC_LOGICAL_BLOCK_ADDRESS_OUT_OF_RANGE,
     ASC_MEDIUM_NOT_PRESENT, CC_KEY_ILLEGAL_REQUEST, CC_KEY_MEDIUM_ERROR, STATUS_CHECK_CONDITION,
@@ -58,6 +59,7 @@ pub(crate) trait ScsiTarget: Send + Debuggable {
     fn write(&mut self, block_offset: usize, data: &[u8]);
     fn image_fn(&self) -> Option<&Path>;
     fn load_media(&mut self, path: &Path) -> Result<()>;
+    fn load_image(&mut self, image: Box<dyn DiskImage>) -> Result<()>;
     fn branch_media(&mut self, path: &Path) -> Result<()>;
     fn media(&self) -> Option<&[u8]>;
 


### PR DESCRIPTION
Extends the approach from #211 to also be used for CD-ROMs, allowing more flexibility and code sharing for disk image loading.

Also includes some small cleanups to `FileDiskImage` in how block size multiples are enforced (it's only needed at creation time, no need to store it as a field).