### PR TITLE
Address some LocalTalk over UDP issues

### DIFF
--- a/core/src/mac/serial_bridge.rs
+++ b/core/src/mac/serial_bridge.rs
@@ -435,4 +435,25 @@ impl SccBridge {
     pub fn is_localtalk(&self) -> bool {
         matches!(self, Self::LocalTalk(_))
     }
+
+    /// Set the node address (LocalTalk only)
+    pub fn set_node_address(&mut self, addr: u8) {
+        if let Self::LocalTalk(bridge) = self {
+            bridge.set_node_address(addr);
+        }
+    }
+
+    /// Set the SDLC address search mode (LocalTalk only)
+    pub fn set_address_search_mode(&mut self, mode: bool) {
+        if let Self::LocalTalk(bridge) = self {
+            bridge.set_address_search_mode(mode);
+        }
+    }
+
+    /// Send a complete SDLC frame (LocalTalk only)
+    pub fn send_frame(&mut self, llap: &[u8]) {
+        if let Self::LocalTalk(bridge) = self {
+            bridge.send_frame(llap);
+        }
+    }
 }


### PR DESCRIPTION
- RX packet filtering: handle_rx_packet() overwrote the local node address with every received packet's destination and queued ALL packets regardless of destination. Now respects Z8530 SDLC address search mode to filter by our node address + broadcast (0xFF), matching real hardware behavior.

- SCC register emulation: Added WR6 (SDLC station address) handling so the Mac's chosen node address is properly communicated to the bridge. Added WR3 bit 2 (address search mode) tracking for RX filtering control.

- SDLC TX frame boundaries: Added WR0 CRC reset command handling (bits 6-7) to detect frame boundaries. Reset TX Underrun/EOM (0b11) signals end of frame, Reset TX CRC (0b10) starts a new frame. Frames are accumulated in a separate buffer and sent as complete LLAP packets.

- RTS/CTS for broadcast: The Mac's SCC driver waits for CTS before sending data frames, even for broadcasts. Previously only unicast RTS generated a CTS response, causing broadcast packets (including ENQ address probes) to stall indefinitely.

- ENQ/ACK collision detection: When another node probes for our settled address, we now respond with ACK to signal the address is taken.