### PR TITLE
Support PREGAP and POSTGAP in cuesheets, Rust 2021 -> 2024

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "snow_core"
 version = "1.3.1"
-edition = "2021"
+edition = "2024"
 build = "build.rs"
 
 [build-dependencies]

--- a/core/src/audio_filter.rs
+++ b/core/src/audio_filter.rs
@@ -1,4 +1,4 @@
-use biquad::{Biquad, Coefficients, DirectForm2Transposed, ToHertz, Q_BUTTERWORTH_F32};
+use biquad::{Biquad, Coefficients, DirectForm2Transposed, Q_BUTTERWORTH_F32, ToHertz};
 use serde::{Deserialize, Serialize};
 
 const SAMPLE_RATE_HZ: f32 = 22254.0;

--- a/core/src/cpu_m68k/alu.rs
+++ b/core/src/cpu_m68k/alu.rs
@@ -7,12 +7,12 @@ use crate::bus::{Address, Bus, IrqSource};
 use crate::types::{Byte, Long, Word};
 
 impl<
-        TBus,
-        const ADDRESS_MASK: Address,
-        const CPU_TYPE: CpuM68kType,
-        const FPU_TYPE: FpuM68kType,
-        const PMMU: bool,
-    > CpuM68k<TBus, ADDRESS_MASK, CPU_TYPE, FPU_TYPE, PMMU>
+    TBus,
+    const ADDRESS_MASK: Address,
+    const CPU_TYPE: CpuM68kType,
+    const FPU_TYPE: FpuM68kType,
+    const PMMU: bool,
+> CpuM68k<TBus, ADDRESS_MASK, CPU_TYPE, FPU_TYPE, PMMU>
 where
     TBus: Bus<Address, u8> + IrqSource,
 {

--- a/core/src/cpu_m68k/bus.rs
+++ b/core/src/cpu_m68k/bus.rs
@@ -1,13 +1,13 @@
 //! M68k CPU - Bus access functionality
 
 use crate::bus::{Address, Bus, BusResult, IrqSource};
-use crate::cpu_m68k::cpu::{Breakpoint, BusBreakpoint, CpuError, CpuM68k, Group0Details};
 use crate::cpu_m68k::FpuM68kType;
+use crate::cpu_m68k::cpu::{Breakpoint, BusBreakpoint, CpuError, CpuM68k, Group0Details};
 use crate::cpu_m68k::{CpuM68kType, CpuSized, M68000, M68020, TORDER_HIGHLOW, TORDER_LOWHIGH};
 use crate::types::Long;
 use crate::types::Word;
 
-use anyhow::{anyhow, bail, Result};
+use anyhow::{Result, anyhow, bail};
 
 // M68k UM 3.8
 pub const FC_UNUSED: u8 = 0;
@@ -18,12 +18,12 @@ pub const FC_SUPERVISOR_PROGRAM: u8 = 6;
 pub const FC_MASK: u8 = 0b1111;
 
 impl<
-        TBus,
-        const ADDRESS_MASK: Address,
-        const CPU_TYPE: CpuM68kType,
-        const FPU_TYPE: FpuM68kType,
-        const PMMU: bool,
-    > CpuM68k<TBus, ADDRESS_MASK, CPU_TYPE, FPU_TYPE, PMMU>
+    TBus,
+    const ADDRESS_MASK: Address,
+    const CPU_TYPE: CpuM68kType,
+    const FPU_TYPE: FpuM68kType,
+    const PMMU: bool,
+> CpuM68k<TBus, ADDRESS_MASK, CPU_TYPE, FPU_TYPE, PMMU>
 where
     TBus: Bus<Address, u8> + IrqSource,
 {
@@ -137,31 +137,32 @@ where
                         _ => e,
                     })?
             };
-            let b: T =
-                loop {
-                    match self.bus.read(byte_addr) {
-                        BusResult::Ok(b) => {
-                            // Trigger bus access breakpoints
-                            if self.breakpoints.iter().any(|bp| {
-                                *bp == Breakpoint::Bus(BusBreakpoint::Read, byte_addr)
-                                    || *bp == Breakpoint::Bus(BusBreakpoint::ReadWrite, byte_addr)
-                            }) {
-                                log::info!(
+            let b: T = loop {
+                match self.bus.read(byte_addr) {
+                    BusResult::Ok(b) => {
+                        // Trigger bus access breakpoints
+                        if self.breakpoints.iter().any(|bp| {
+                            *bp == Breakpoint::Bus(BusBreakpoint::Read, byte_addr)
+                                || *bp == Breakpoint::Bus(BusBreakpoint::ReadWrite, byte_addr)
+                        }) {
+                            log::info!(
                                 "Breakpoint hit (bus read): ${:08X}, value: ${:02X}, PC: ${:08X}",
-                                byte_addr, b, self.regs.pc,
+                                byte_addr,
+                                b,
+                                self.regs.pc,
                             );
-                                self.breakpoint_hit.set();
-                            }
-                            break b.into();
+                            self.breakpoint_hit.set();
                         }
-                        BusResult::WaitState => {
-                            // Insert wait states until bus access succeeds
-                            self.history_current.waitstates = true;
-                            self.advance_cycles(2)?;
-                            self.sync_bus()?;
-                        }
+                        break b.into();
                     }
-                };
+                    BusResult::WaitState => {
+                        // Insert wait states until bus access succeeds
+                        self.history_current.waitstates = true;
+                        self.advance_cycles(2)?;
+                        self.sync_bus()?;
+                    }
+                }
+            };
             result = result.wrapping_shl(8) | b;
 
             if CPU_TYPE < M68020 {

--- a/core/src/cpu_m68k/cpu.rs
+++ b/core/src/cpu_m68k/cpu.rs
@@ -1,7 +1,7 @@
 use crate::cpu_m68k::FpuM68kType;
 use std::collections::VecDeque;
 
-use anyhow::{bail, Result};
+use anyhow::{Result, bail};
 use arrayvec::ArrayVec;
 use either::Either;
 use log::*;
@@ -337,12 +337,12 @@ pub struct CpuM68k<
 }
 
 impl<
-        TBus,
-        const ADDRESS_MASK: Address,
-        const CPU_TYPE: CpuM68kType,
-        const FPU_TYPE: FpuM68kType,
-        const PMMU: bool,
-    > CpuM68k<TBus, ADDRESS_MASK, CPU_TYPE, FPU_TYPE, PMMU>
+    TBus,
+    const ADDRESS_MASK: Address,
+    const CPU_TYPE: CpuM68kType,
+    const FPU_TYPE: FpuM68kType,
+    const PMMU: bool,
+> CpuM68k<TBus, ADDRESS_MASK, CPU_TYPE, FPU_TYPE, PMMU>
 where
     TBus: Bus<Address, u8> + IrqSource,
 {
@@ -4086,12 +4086,12 @@ where
 }
 
 impl<
-        TBus,
-        const ADDRESS_MASK: Address,
-        const CPU_TYPE: CpuM68kType,
-        const FPU_TYPE: FpuM68kType,
-        const PMMU: bool,
-    > Tickable for CpuM68k<TBus, ADDRESS_MASK, CPU_TYPE, FPU_TYPE, PMMU>
+    TBus,
+    const ADDRESS_MASK: Address,
+    const CPU_TYPE: CpuM68kType,
+    const FPU_TYPE: FpuM68kType,
+    const PMMU: bool,
+> Tickable for CpuM68k<TBus, ADDRESS_MASK, CPU_TYPE, FPU_TYPE, PMMU>
 where
     TBus: Bus<Address, u8> + IrqSource,
 {

--- a/core/src/cpu_m68k/disassembler.rs
+++ b/core/src/cpu_m68k/disassembler.rs
@@ -1,4 +1,4 @@
-use anyhow::{bail, Context, Result};
+use anyhow::{Context, Result, bail};
 use arrayvec::ArrayVec;
 use either::Either;
 use itertools::Itertools;
@@ -15,12 +15,12 @@ use crate::cpu_m68k::pmmu::instruction::PtestExtword;
 use crate::cpu_m68k::regs::Register;
 use crate::types::{Byte, Word};
 
+use super::CpuM68kType;
 use super::fpu::instruction::{FmoveControlReg, FmoveExtWord};
 use super::instruction::{
     AddressingMode, Direction, Instruction, InstructionMnemonic, InstructionSize,
 };
 use super::pmmu::instruction::Pmove1Extword;
-use super::CpuM68kType;
 
 #[derive(Clone)]
 pub struct DisassemblyEntry {

--- a/core/src/cpu_m68k/ea.rs
+++ b/core/src/cpu_m68k/ea.rs
@@ -1,7 +1,7 @@
 //! M68k CPU - Effective Address / Addressing modes handling
 
 use crate::cpu_m68k::FpuM68kType;
-use anyhow::{bail, Result};
+use anyhow::{Result, bail};
 use arrayvec::ArrayVec;
 
 use crate::bus::{Address, Bus, IrqSource};
@@ -13,12 +13,12 @@ use super::instruction::{AddressingMode, IndexSize, Instruction, Xn};
 use super::{CpuM68kType, CpuSized, M68020, TORDER_HIGHLOW};
 
 impl<
-        TBus,
-        const ADDRESS_MASK: Address,
-        const CPU_TYPE: CpuM68kType,
-        const FPU_TYPE: FpuM68kType,
-        const PMMU: bool,
-    > CpuM68k<TBus, ADDRESS_MASK, CPU_TYPE, FPU_TYPE, PMMU>
+    TBus,
+    const ADDRESS_MASK: Address,
+    const CPU_TYPE: CpuM68kType,
+    const FPU_TYPE: FpuM68kType,
+    const PMMU: bool,
+> CpuM68k<TBus, ADDRESS_MASK, CPU_TYPE, FPU_TYPE, PMMU>
 where
     TBus: Bus<Address, u8> + IrqSource,
 {

--- a/core/src/cpu_m68k/fpu/alu.rs
+++ b/core/src/cpu_m68k/fpu/alu.rs
@@ -1,25 +1,25 @@
 use crate::cpu_m68k::FpuM68kType;
-use anyhow::{bail, Result};
+use anyhow::{Result, bail};
 use arpfloat::{Float, RoundingMode, Semantics};
 
 use crate::bus::{Address, Bus, IrqSource};
 
+use crate::cpu_m68k::CpuM68kType;
 use crate::cpu_m68k::cpu::CpuM68k;
 use crate::cpu_m68k::fpu::math::FloatMath;
 use crate::cpu_m68k::fpu::ops_generic::FPU_CYCLES_LEN;
 use crate::cpu_m68k::fpu::trig::FloatTrig;
-use crate::cpu_m68k::CpuM68kType;
 use crate::tickable::Ticks;
 
 use super::{SEMANTICS_DOUBLE, SEMANTICS_EXTENDED, SEMANTICS_SINGLE};
 
 impl<
-        TBus,
-        const ADDRESS_MASK: Address,
-        const CPU_TYPE: CpuM68kType,
-        const FPU_TYPE: FpuM68kType,
-        const PMMU: bool,
-    > CpuM68k<TBus, ADDRESS_MASK, CPU_TYPE, FPU_TYPE, PMMU>
+    TBus,
+    const ADDRESS_MASK: Address,
+    const CPU_TYPE: CpuM68kType,
+    const FPU_TYPE: FpuM68kType,
+    const PMMU: bool,
+> CpuM68k<TBus, ADDRESS_MASK, CPU_TYPE, FPU_TYPE, PMMU>
 where
     TBus: Bus<Address, u8> + IrqSource,
 {

--- a/core/src/cpu_m68k/fpu/ops_branch.rs
+++ b/core/src/cpu_m68k/fpu/ops_branch.rs
@@ -1,20 +1,20 @@
 use crate::cpu_m68k::FpuM68kType;
-use anyhow::{bail, Result};
+use anyhow::{Result, bail};
 
 use crate::bus::{Address, Bus, IrqSource};
 
+use crate::cpu_m68k::CpuM68kType;
 use crate::cpu_m68k::cpu::CpuM68k;
 use crate::cpu_m68k::instruction::Instruction;
-use crate::cpu_m68k::CpuM68kType;
 use crate::types::Byte;
 
 impl<
-        TBus,
-        const ADDRESS_MASK: Address,
-        const CPU_TYPE: CpuM68kType,
-        const FPU_TYPE: FpuM68kType,
-        const PMMU: bool,
-    > CpuM68k<TBus, ADDRESS_MASK, CPU_TYPE, FPU_TYPE, PMMU>
+    TBus,
+    const ADDRESS_MASK: Address,
+    const CPU_TYPE: CpuM68kType,
+    const FPU_TYPE: FpuM68kType,
+    const PMMU: bool,
+> CpuM68k<TBus, ADDRESS_MASK, CPU_TYPE, FPU_TYPE, PMMU>
 where
     TBus: Bus<Address, u8> + IrqSource,
 {

--- a/core/src/cpu_m68k/fpu/ops_generic.rs
+++ b/core/src/cpu_m68k/fpu/ops_generic.rs
@@ -1,5 +1,5 @@
 use crate::cpu_m68k::FpuM68kType;
-use anyhow::{bail, Result};
+use anyhow::{Result, bail};
 use arpfloat::Float;
 use either::Either;
 use num_traits::ToPrimitive;
@@ -8,10 +8,10 @@ use strum::IntoEnumIterator;
 use crate::bus::{Address, Bus, IrqSource};
 
 use crate::cpu_m68k::cpu::CpuM68k;
+use crate::cpu_m68k::fpu::SEMANTICS_EXTENDED;
 use crate::cpu_m68k::fpu::instruction::{FmoveControlReg, FmoveExtWord};
 use crate::cpu_m68k::fpu::math::FloatMath;
 use crate::cpu_m68k::fpu::regs::FpuRegisterFile;
-use crate::cpu_m68k::fpu::SEMANTICS_EXTENDED;
 use crate::cpu_m68k::instruction::{AddressingMode, Instruction};
 use crate::cpu_m68k::{CpuM68kType, FPU_M68881, FPU_M68882};
 use crate::types::{Byte, Long, Word};
@@ -29,12 +29,12 @@ pub(in crate::cpu_m68k::fpu) const FPU_CYCLES_MEM_PACKED: usize = 5;
 pub(in crate::cpu_m68k::fpu) const FPU_CYCLES_LEN: usize = 6;
 
 impl<
-        TBus,
-        const ADDRESS_MASK: Address,
-        const CPU_TYPE: CpuM68kType,
-        const FPU_TYPE: FpuM68kType,
-        const PMMU: bool,
-    > CpuM68k<TBus, ADDRESS_MASK, CPU_TYPE, FPU_TYPE, PMMU>
+    TBus,
+    const ADDRESS_MASK: Address,
+    const CPU_TYPE: CpuM68kType,
+    const FPU_TYPE: FpuM68kType,
+    const PMMU: bool,
+> CpuM68k<TBus, ADDRESS_MASK, CPU_TYPE, FPU_TYPE, PMMU>
 where
     TBus: Bus<Address, u8> + IrqSource,
 {

--- a/core/src/cpu_m68k/fpu/regs.rs
+++ b/core/src/cpu_m68k/fpu/regs.rs
@@ -1,6 +1,6 @@
 use crate::bus::Address;
-use crate::cpu_m68k::fpu::storage::float_array_as_ext_real;
 use crate::cpu_m68k::fpu::SEMANTICS_EXTENDED;
+use crate::cpu_m68k::fpu::storage::float_array_as_ext_real;
 use crate::types::{Byte, Long};
 use arpfloat::Float;
 use num_traits::Zero;

--- a/core/src/cpu_m68k/fpu/storage.rs
+++ b/core/src/cpu_m68k/fpu/storage.rs
@@ -6,7 +6,7 @@ use proc_bitfield::bitfield;
 use serde::{Deserialize, Serialize};
 
 use crate::bus::{Address, Bus, IrqSource};
-use crate::cpu_m68k::{cpu::CpuM68k, CpuM68kType};
+use crate::cpu_m68k::{CpuM68kType, cpu::CpuM68k};
 use crate::types::{Long, Word};
 
 use super::SEMANTICS_EXTENDED;
@@ -206,12 +206,12 @@ impl From<BitsExtReal> for Float {
 }
 
 impl<
-        TBus,
-        const ADDRESS_MASK: Address,
-        const CPU_TYPE: CpuM68kType,
-        const FPU_TYPE: FpuM68kType,
-        const PMMU: bool,
-    > CpuM68k<TBus, ADDRESS_MASK, CPU_TYPE, FPU_TYPE, PMMU>
+    TBus,
+    const ADDRESS_MASK: Address,
+    const CPU_TYPE: CpuM68kType,
+    const FPU_TYPE: FpuM68kType,
+    const PMMU: bool,
+> CpuM68k<TBus, ADDRESS_MASK, CPU_TYPE, FPU_TYPE, PMMU>
 where
     TBus: Bus<Address, u8> + IrqSource,
 {
@@ -588,8 +588,8 @@ where
 
 #[cfg(test)]
 mod tests {
-    use crate::bus::testbus::Testbus;
     use crate::bus::Address;
+    use crate::bus::testbus::Testbus;
     use crate::cpu_m68k::{CpuM68020Fpu, M68020_ADDRESS_MASK};
     use crate::types::Byte;
 

--- a/core/src/cpu_m68k/instruction.rs
+++ b/core/src/cpu_m68k/instruction.rs
@@ -1,6 +1,6 @@
 use std::cell::Cell;
 
-use anyhow::{anyhow, bail, Context, Result};
+use anyhow::{Context, Result, anyhow, bail};
 use either::Either;
 use num_derive::FromPrimitive;
 use num_traits::FromPrimitive;

--- a/core/src/cpu_m68k/pmmu/ops.rs
+++ b/core/src/cpu_m68k/pmmu/ops.rs
@@ -1,26 +1,26 @@
 //! M68851 PMMU - Opcode implementations
 
 use crate::cpu_m68k::{FpuM68kType, M68030};
-use anyhow::{bail, Result};
+use anyhow::{Result, bail};
 
 use crate::bus::{Address, Bus, IrqSource};
+use crate::cpu_m68k::CpuM68kType;
 use crate::cpu_m68k::bus::FC_MASK;
 use crate::cpu_m68k::cpu::{CpuM68k, ExceptionGroup, VECTOR_PRIVILEGE_VIOLATION};
 use crate::cpu_m68k::instruction::Instruction;
 use crate::cpu_m68k::pmmu::instruction::{Pmove3Extword, PtestExtword};
-use crate::cpu_m68k::CpuM68kType;
 use crate::types::{DoubleLong, Long, Word};
 
 use super::instruction::Pmove1Extword;
 use super::regs::TcReg;
 
 impl<
-        TBus,
-        const ADDRESS_MASK: Address,
-        const CPU_TYPE: CpuM68kType,
-        const FPU_TYPE: FpuM68kType,
-        const PMMU: bool,
-    > CpuM68k<TBus, ADDRESS_MASK, CPU_TYPE, FPU_TYPE, PMMU>
+    TBus,
+    const ADDRESS_MASK: Address,
+    const CPU_TYPE: CpuM68kType,
+    const FPU_TYPE: FpuM68kType,
+    const PMMU: bool,
+> CpuM68k<TBus, ADDRESS_MASK, CPU_TYPE, FPU_TYPE, PMMU>
 where
     TBus: Bus<Address, u8> + IrqSource,
 {

--- a/core/src/cpu_m68k/pmmu/translate.rs
+++ b/core/src/cpu_m68k/pmmu/translate.rs
@@ -1,11 +1,11 @@
 use crate::bus::{Address, Bus, IrqSource};
-use crate::cpu_m68k::cpu::{CpuError, CpuM68k, Group0Details, HistoryEntry};
-use crate::cpu_m68k::pmmu::regs::{PmmuPageDescriptorType, RegisterPSR, RootPointerReg};
 use crate::cpu_m68k::CpuM68kType;
 use crate::cpu_m68k::FpuM68kType;
+use crate::cpu_m68k::cpu::{CpuError, CpuM68k, Group0Details, HistoryEntry};
+use crate::cpu_m68k::pmmu::regs::{PmmuPageDescriptorType, RegisterPSR, RootPointerReg};
 use crate::types::Long;
 
-use anyhow::{anyhow, bail, Result};
+use anyhow::{Result, anyhow, bail};
 use arrayvec::ArrayVec;
 use num_traits::FromPrimitive;
 use proc_bitfield::bitfield;
@@ -94,12 +94,12 @@ bitfield! {
 }
 
 impl<
-        TBus,
-        const ADDRESS_MASK: Address,
-        const CPU_TYPE: CpuM68kType,
-        const FPU_TYPE: FpuM68kType,
-        const PMMU: bool,
-    > CpuM68k<TBus, ADDRESS_MASK, CPU_TYPE, FPU_TYPE, PMMU>
+    TBus,
+    const ADDRESS_MASK: Address,
+    const CPU_TYPE: CpuM68kType,
+    const FPU_TYPE: FpuM68kType,
+    const PMMU: bool,
+> CpuM68k<TBus, ADDRESS_MASK, CPU_TYPE, FPU_TYPE, PMMU>
 where
     TBus: Bus<Address, u8> + IrqSource,
 {

--- a/core/src/cpu_m68k/regs.rs
+++ b/core/src/cpu_m68k/regs.rs
@@ -426,11 +426,7 @@ impl RegisterFile {
 
     /// Reference to active SSP
     pub fn ssp(&self) -> &Address {
-        if self.sr.m() {
-            &self.msp
-        } else {
-            &self.isp
-        }
+        if self.sr.m() { &self.msp } else { &self.isp }
     }
 }
 

--- a/core/src/cpu_m68k/tests/group2_exceptions.rs
+++ b/core/src/cpu_m68k/tests/group2_exceptions.rs
@@ -2,8 +2,8 @@
 //!
 //! Ported with permission from tests written by Howard Price
 
-use crate::bus::testbus::Testbus;
 use crate::bus::Address;
+use crate::bus::testbus::Testbus;
 use crate::cpu_m68k::{CpuM68000, M68000_ADDRESS_MASK};
 use crate::types::{Long, Word};
 

--- a/core/src/cpu_m68k/tests/illegal_exception.rs
+++ b/core/src/cpu_m68k/tests/illegal_exception.rs
@@ -2,8 +2,8 @@
 //!
 //! Ported with permission from tests written by Howard Price
 
-use crate::bus::testbus::Testbus;
 use crate::bus::Address;
+use crate::bus::testbus::Testbus;
 use crate::cpu_m68k::instruction::Instruction;
 use crate::cpu_m68k::{CpuM68000, M68000, M68000_ADDRESS_MASK};
 use crate::types::{Long, Word};

--- a/core/src/cpu_m68k/tests/interrupt.rs
+++ b/core/src/cpu_m68k/tests/interrupt.rs
@@ -2,8 +2,8 @@
 //!
 //! Ported with permission from tests written by Howard Price
 
-use crate::bus::testbus::Testbus;
 use crate::bus::Address;
+use crate::bus::testbus::Testbus;
 use crate::cpu_m68k::{CpuM68000, M68000_ADDRESS_MASK};
 use crate::types::{Long, Word};
 

--- a/core/src/cpu_m68k/tests/privilege_violation.rs
+++ b/core/src/cpu_m68k/tests/privilege_violation.rs
@@ -2,8 +2,8 @@
 //!
 //! Ported with permission from tests written by Howard Price
 
-use crate::bus::testbus::Testbus;
 use crate::bus::Address;
+use crate::bus::testbus::Testbus;
 use crate::cpu_m68k::{CpuM68000, M68000_ADDRESS_MASK};
 use crate::types::{Long, Word};
 

--- a/core/src/cpu_m68k/tests/privilege_violation_68020.rs
+++ b/core/src/cpu_m68k/tests/privilege_violation_68020.rs
@@ -7,8 +7,8 @@
 //!
 //! Ported with permission from tests written by Howard Price
 
-use crate::bus::testbus::Testbus;
 use crate::bus::Address;
+use crate::bus::testbus::Testbus;
 use crate::cpu_m68k::{CpuM68020Fpu, M68020_ADDRESS_MASK};
 use crate::types::{Long, Word};
 

--- a/core/src/cpu_m68k/tests/trace.rs
+++ b/core/src/cpu_m68k/tests/trace.rs
@@ -2,8 +2,8 @@
 //!
 //! Ported with permission from tests written by Howard Price
 
-use crate::bus::testbus::Testbus;
 use crate::bus::Address;
+use crate::bus::testbus::Testbus;
 use crate::cpu_m68k::{CpuM68000, M68000_ADDRESS_MASK};
 use crate::types::{Long, Word};
 

--- a/core/src/emulator/comm.rs
+++ b/core/src/emulator/comm.rs
@@ -11,12 +11,12 @@ use crate::cpu_m68k::regs::{Register, RegisterFile};
 use crate::debuggable::DebuggableProperties;
 use crate::emulator::MouseMode;
 use crate::keymap::KeyEvent;
+use crate::mac::MacModel;
 use crate::mac::scc::SccCh;
 #[cfg(feature = "ethernet")]
 use crate::mac::scsi::ethernet::EthernetLinkType;
 use crate::mac::scsi::target::ScsiTargetType;
 use crate::mac::serial_bridge::{SerialBridgeConfig, SerialBridgeStatus};
-use crate::mac::MacModel;
 use crate::tickable::Ticks;
 
 pub use crate::cpu_m68k::cpu::{Breakpoint, BusBreakpoint};

--- a/core/src/emulator/mod.rs
+++ b/core/src/emulator/mod.rs
@@ -4,8 +4,8 @@ pub mod comm;
 pub mod save;
 
 use serde::{Deserialize, Serialize};
-use snow_floppy::loaders::{Autodetect, FloppyImageLoader, FloppyImageSaver, Moof};
 use snow_floppy::Floppy;
+use snow_floppy::loaders::{Autodetect, FloppyImageLoader, FloppyImageSaver, Moof};
 use std::collections::VecDeque;
 #[cfg(feature = "savestates")]
 use std::fs::File;
@@ -31,13 +31,13 @@ use crate::mac::scsi::target::ScsiTargetEvent;
 use crate::mac::serial_bridge::{SccBridge, SerialBridgeStatus};
 use crate::mac::swim::drive::DriveType;
 use crate::mac::{ExtraROMs, MacModel, MacMonitor};
-use crate::renderer::channel::ChannelRenderer;
 use crate::renderer::AudioProvider;
+use crate::renderer::channel::ChannelRenderer;
 use crate::renderer::{DisplayBuffer, Renderer};
 use crate::tickable::{Tickable, Ticks};
 use crate::types::Byte;
 
-use anyhow::{bail, Context, Result};
+use anyhow::{Context, Result, bail};
 use bit_set::BitSet;
 use log::*;
 use std::fmt;
@@ -1266,11 +1266,11 @@ impl Tickable for Emulator {
             }
 
             // Replay next step in recording if currently replaying
-            if let Some((t, c)) = self.replay_input.front() {
-                if *t <= self.get_cycles() {
-                    self.command_sender.send(c.clone()).unwrap();
-                    self.replay_input.pop_front().unwrap();
-                }
+            if let Some((t, c)) = self.replay_input.front()
+                && *t <= self.get_cycles()
+            {
+                self.command_sender.send(c.clone()).unwrap();
+                self.replay_input.pop_front().unwrap();
             }
 
             // Batch 10000 steps for performance reasons
@@ -1290,48 +1290,44 @@ impl Tickable for Emulator {
                         .config
                         .scc()
                         .is_rx_ready_for_data(crate::mac::scc::SccCh::B)
+                    && let Some(ref mut bridge) = self.serial_bridges[1]
+                    && bridge.is_localtalk()
                 {
-                    if let Some(ref mut bridge) = self.serial_bridges[1] {
-                        if bridge.is_localtalk() {
-                            // Propagate SCC state to LocalTalk bridge
-                            let sdlc_addr =
-                                self.config.scc().sdlc_address(crate::mac::scc::SccCh::B);
-                            bridge.set_node_address(sdlc_addr);
-                            bridge.set_address_search_mode(
-                                self.config
-                                    .scc()
-                                    .is_address_search_mode(crate::mac::scc::SccCh::B),
-                            );
+                    // Propagate SCC state to LocalTalk bridge
+                    let sdlc_addr = self.config.scc().sdlc_address(crate::mac::scc::SccCh::B);
+                    bridge.set_node_address(sdlc_addr);
+                    bridge.set_address_search_mode(
+                        self.config
+                            .scc()
+                            .is_address_search_mode(crate::mac::scc::SccCh::B),
+                    );
 
-                            // Prefer SDLC frame-boundary path if frames are ready
-                            let frames = self
-                                .config
-                                .scc_mut()
-                                .take_tx_frames(crate::mac::scc::SccCh::B);
-                            if !frames.is_empty() {
-                                for frame in &frames {
-                                    bridge.send_frame(frame);
-                                }
-                                // Drain tx_queue to avoid double-sending
-                                self.config.scc_mut().take_tx(crate::mac::scc::SccCh::B);
-                            }
-
-                            // Byte-stream TX path (fallback when no frame boundaries detected)
-                            if self.config.scc().has_tx_data(crate::mac::scc::SccCh::B) {
-                                let tx_data =
-                                    self.config.scc_mut().take_tx(crate::mac::scc::SccCh::B);
-                                bridge.write_from_scc(&tx_data);
-                            }
-
-                            // Now poll for incoming data and pending CTS
-                            bridge.poll();
-                            let rx_data = bridge.read_to_scc();
-                            if !rx_data.is_empty() {
-                                self.config
-                                    .scc_mut()
-                                    .push_rx(crate::mac::scc::SccCh::B, &rx_data);
-                            }
+                    // Prefer SDLC frame-boundary path if frames are ready
+                    let frames = self
+                        .config
+                        .scc_mut()
+                        .take_tx_frames(crate::mac::scc::SccCh::B);
+                    if !frames.is_empty() {
+                        for frame in &frames {
+                            bridge.send_frame(frame);
                         }
+                        // Drain tx_queue to avoid double-sending
+                        self.config.scc_mut().take_tx(crate::mac::scc::SccCh::B);
+                    }
+
+                    // Byte-stream TX path (fallback when no frame boundaries detected)
+                    if self.config.scc().has_tx_data(crate::mac::scc::SccCh::B) {
+                        let tx_data = self.config.scc_mut().take_tx(crate::mac::scc::SccCh::B);
+                        bridge.write_from_scc(&tx_data);
+                    }
+
+                    // Now poll for incoming data and pending CTS
+                    bridge.poll();
+                    let rx_data = bridge.read_to_scc();
+                    if !rx_data.is_empty() {
+                        self.config
+                            .scc_mut()
+                            .push_rx(crate::mac::scc::SccCh::B, &rx_data);
                     }
                 }
             }

--- a/core/src/emulator/mod.rs
+++ b/core/src/emulator/mod.rs
@@ -1102,7 +1102,7 @@ impl Tickable for Emulator {
                                 let status = bridge.status();
                                 info!("SCC bridge enabled on channel {:?}: {}", ch, status);
                                 match &status {
-                                    SerialBridgeStatus::Pty(ref path) => {
+                                    SerialBridgeStatus::Pty(path) => {
                                         self.user_notice(&format!(
                                             "Serial bridge PTY: {}",
                                             path.display()
@@ -1140,7 +1140,7 @@ impl Tickable for Emulator {
                         }
                     }
                     EmulatorCommand::SetDebugFramebuffers(v) => {
-                        if let EmulatorConfig::Compact(ref mut c) = &mut self.config {
+                        if let EmulatorConfig::Compact(c) = &mut self.config {
                             c.bus.video.debug_framebuffers = v;
                         }
                     }

--- a/core/src/emulator/save.rs
+++ b/core/src/emulator/save.rs
@@ -1,9 +1,9 @@
 use std::fs::File;
 use std::io::Read;
 
-use anyhow::{bail, Result};
+use anyhow::{Result, bail};
 use binrw::io::NoSeek;
-use binrw::{binrw, BinRead, BinWrite, NullString};
+use binrw::{BinRead, BinWrite, NullString, binrw};
 
 use crate::emulator::EmulatorConfig;
 use crate::mac::scsi::controller::ScsiController;

--- a/core/src/mac/adb/keyboard.rs
+++ b/core/src/mac/adb/keyboard.rs
@@ -76,7 +76,7 @@ impl AdbDevice for AdbKeyboard {
         match event {
             AdbEvent::Key(ke) => self.event_queue.push_back(*ke),
             AdbEvent::ReleaseAll => {
-                for (sc, _) in self.keystate.iter().enumerate().filter(|(_, &s)| s) {
+                for (sc, _) in self.keystate.iter().enumerate().filter(|(_, s)| **s) {
                     self.event_queue
                         .push_back(KeyEvent::KeyUp(sc.try_into().unwrap(), Self::KEYMAP));
                 }

--- a/core/src/mac/asc.rs
+++ b/core/src/mac/asc.rs
@@ -3,7 +3,7 @@ use std::collections::VecDeque;
 use crate::audio_filter::AudioFilter;
 use crate::bus::{Address, BusMember};
 use crate::debuggable::Debuggable;
-use crate::renderer::{null_audio_sink, AudioSink, AUDIO_BUFFER_SIZE};
+use crate::renderer::{AUDIO_BUFFER_SIZE, AudioSink, null_audio_sink};
 use crate::tickable::Ticks;
 use crate::types::{Byte, Field32};
 use anyhow::Result;

--- a/core/src/mac/compact/audio.rs
+++ b/core/src/mac/compact/audio.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use serde::{Deserialize, Serialize};
 
 use crate::audio_filter::AudioFilter;
-use crate::renderer::{null_audio_sink, AudioSink, AUDIO_BUFFER_SIZE, AUDIO_CHANNELS};
+use crate::renderer::{AUDIO_BUFFER_SIZE, AUDIO_CHANNELS, AudioSink, null_audio_sink};
 
 #[derive(Serialize, Deserialize)]
 pub struct AudioState {

--- a/core/src/mac/compact/bus.rs
+++ b/core/src/mac/compact/bus.rs
@@ -9,16 +9,16 @@ use crate::debuggable::Debuggable;
 use crate::emulator::comm::EmulatorSpeed;
 use crate::emulator::{EmuContext, MouseMode};
 use crate::keymap::KeyEvent;
+use crate::mac::MacModel;
 use crate::mac::adb::{AdbEvent, AdbKeyboard, AdbMouse};
 use crate::mac::rtc::Rtc;
 use crate::mac::scc::{Scc, SccCh};
 use crate::mac::scsi::controller::ScsiController;
-use crate::mac::swim::drive::DriveType;
 use crate::mac::swim::Swim;
+use crate::mac::swim::drive::DriveType;
 use crate::mac::via::Via;
-use crate::mac::MacModel;
 use crate::renderer::{
-    null_audio_sink, AudioProvider, Renderer, AUDIO_BUFFER_SAMPLES, AUDIO_CHANNELS,
+    AUDIO_BUFFER_SAMPLES, AUDIO_CHANNELS, AudioProvider, Renderer, null_audio_sink,
 };
 use crate::tickable::{Tickable, Ticks};
 use crate::types::{Byte, LatchingEvent, MouseEvent};

--- a/core/src/mac/macii/bus.rs
+++ b/core/src/mac/macii/bus.rs
@@ -9,9 +9,9 @@ use crate::emulator::{EmuContext, MouseMode};
 use crate::keymap::KeyEvent;
 use crate::mac::adb::{AdbEvent, AdbKeyboard, AdbMouse};
 use crate::mac::asc::Asc;
+use crate::mac::nubus::NubusCard;
 use crate::mac::nubus::mdc12::Mdc12;
 use crate::mac::nubus::se30video::SE30Video;
-use crate::mac::nubus::NubusCard;
 use crate::mac::rtc::Rtc;
 use crate::mac::scc::Scc;
 use crate::mac::scsi::controller::ScsiController;
@@ -19,7 +19,7 @@ use crate::mac::swim::Swim;
 use crate::mac::via::Via;
 use crate::mac::{MacModel, MacMonitor};
 use crate::renderer::{
-    null_audio_sink, AudioProvider, Renderer, AUDIO_BUFFER_SAMPLES, AUDIO_CHANNELS,
+    AUDIO_BUFFER_SAMPLES, AUDIO_CHANNELS, AudioProvider, Renderer, null_audio_sink,
 };
 use crate::tickable::{Tickable, Ticks};
 use crate::types::{Byte, LatchingEvent, MouseEvent};

--- a/core/src/mac/nubus/mdc12.rs
+++ b/core/src/mac/nubus/mdc12.rs
@@ -297,11 +297,7 @@ where
                 if addr == 0x20_01C3 {
                     self.toggle = !self.toggle;
                 }
-                if self.toggle {
-                    Some(0)
-                } else {
-                    Some(4)
-                }
+                if self.toggle { Some(0) } else { Some(4) }
             }
             // This has to read 0
             0x20_01C4..=0x20_01CF => Some(0),

--- a/core/src/mac/pluskbd.rs
+++ b/core/src/mac/pluskbd.rs
@@ -47,7 +47,7 @@ impl PlusKeyboard {
     }
 
     pub fn release_all(&mut self) {
-        for (sc, _) in self.keystate.iter().enumerate().filter(|(_, &s)| s) {
+        for (sc, _) in self.keystate.iter().enumerate().filter(|(_, s)| **s) {
             self.event_queue
                 .push_back(KeyEvent::KeyUp(sc.try_into().unwrap(), Self::KEYMAP));
         }

--- a/core/src/mac/scsi/cdrom/backends/cuesheet.rs
+++ b/core/src/mac/scsi/cdrom/backends/cuesheet.rs
@@ -333,7 +333,7 @@ impl CuesheetCdromBackend {
             .map(|e| e.sector + e.sector_count)
             .unwrap_or(LBA_START_SECTOR);
 
-        let self_ = Self {
+        Ok(Self {
             cue_path: path.into(),
             data_files,
             sessions: vec![SessionInfo {
@@ -341,20 +341,7 @@ impl CuesheetCdromBackend {
                 tracks,
             }],
             sector_map,
-        };
-
-        let test_sector = 20934;
-        let test = self_.find_map_entry_for_sector(test_sector);
-        log::debug!("map entry for sector {}: {:#?}", test_sector, test);
-        log::debug!("sector {} is at rel sector {}", test_sector, test_sector - test.unwrap().sector);
-        let test_source = match test.unwrap().source {
-            SectorSource::DataFile{ data_file_idx: _, data_file_sector } => data_file_sector,
-            _ => unreachable!()
-        };
-        let file_sector = test_source + test_sector - test.unwrap().sector;
-        log::debug!("sector {} is at file sector {} (file offset 0x{:X})", test_sector, file_sector, file_sector * 2352);
-
-        Ok(self_)
+        })
     }
 
     fn find_map_entry_for_sector(&self, sector: u32) -> Option<&SectorMapEntry> {

--- a/core/src/mac/scsi/cdrom/backends/cuesheet.rs
+++ b/core/src/mac/scsi/cdrom/backends/cuesheet.rs
@@ -1,4 +1,4 @@
-use anyhow::{anyhow, bail, Result};
+use anyhow::{Result, anyhow, bail};
 use std::{
     fs::File,
     io::{BufRead, BufReader, Read, Seek, SeekFrom},
@@ -8,8 +8,8 @@ use std::{
 };
 
 use crate::mac::scsi::cdrom::{
-    CdromBackend, Msf, SessionInfo, TrackInfo, AUDIO_TRACK, DATA_TRACK, LBA_START_SECTOR,
-    RAW_SECTOR_LEN,
+    AUDIO_TRACK, CdromBackend, DATA_TRACK, LBA_START_SECTOR, Msf, RAW_SECTOR_LEN, SessionInfo,
+    TrackInfo,
 };
 
 // .cue file reference:
@@ -81,16 +81,143 @@ fn read_cue_msf(reader: &mut Peekable<Chars>) -> Result<Msf> {
 }
 
 struct CuesheetDataFile {
-    /// Absolute sector number where the data file resides on the CD
-    sector: u32,
+    /// Number of sectors in data file (not counting pregaps and postgaps)
+    #[allow(unused)]
     sector_count: u32,
     file: File,
+}
+
+#[derive(Debug)]
+enum SectorSource {
+    /// Sectors filled with zeroes. Used for pregaps and postgaps.
+    Zeros,
+    /// Sectors sourced from a data file
+    DataFile {
+        /// Index of file in the data_files array
+        data_file_idx: usize,
+        /// Sector number relative to the beginning of the file
+        data_file_sector: u32,
+    },
+}
+
+#[derive(Debug)]
+struct SectorMapEntry {
+    sector: u32,
+    sector_count: u32,
+    source: SectorSource,
+}
+
+struct SectorMapBuilder {
+    /// Absolute sector number
+    abs_cursor: u32,
+    /// Sector number within current data file
+    data_file_cursor: u32,
+    /// Max sectors in current data file
+    data_file_max: u32,
+    /// Index of current data file in the cuesheet's `data_files` array
+    data_file_idx: usize,
+    map: Vec<SectorMapEntry>,
+}
+
+impl SectorMapBuilder {
+    fn new() -> Self {
+        // Data files always start at time 00:02:00 (sector 150).
+        // This means there are 150 sectors located in the lead-in area which
+        // cannot be specified by the .bin/.cue format.
+        // These sectors are usually empty, but sometimes they contain various
+        // data such as CD-TEXT information.
+        SectorMapBuilder {
+            abs_cursor: LBA_START_SECTOR,
+            data_file_cursor: 0,
+            data_file_max: 0,
+            data_file_idx: 0,
+            map: vec![],
+        }
+    }
+
+    fn start_new_data_file(&mut self, idx: usize, max: u32) -> Result<()> {
+        // If a data file exists, add the rest of its sectors before starting the new file
+        self.add_rest_of_data_file()?;
+        self.data_file_cursor = 0;
+        self.data_file_idx = idx;
+        self.data_file_max = max;
+
+        Ok(())
+    }
+
+    /// Add data sectors up to a given sector number within the data file
+    fn add_data_up_to(&mut self, up_to: u32) -> Result<()> {
+        if up_to < self.data_file_cursor {
+            bail!("Data file sector number cannot decrease");
+        }
+
+        if up_to > self.data_file_max {
+            bail!("Data file sector number exceeded max");
+        }
+
+        let additional = up_to - self.data_file_cursor;
+
+        if let Some(entry) = self.map.last_mut()
+            && let SectorSource::DataFile { data_file_idx, .. } = entry.source
+            && data_file_idx == self.data_file_idx
+        {
+            // Add more sectors to the existing map entry
+            entry.sector_count += additional;
+        } else if additional > 0 {
+            // Start a new map entry
+            self.map.push(SectorMapEntry {
+                sector: self.abs_cursor,
+                sector_count: additional,
+                source: SectorSource::DataFile {
+                    data_file_idx: self.data_file_idx,
+                    data_file_sector: self.data_file_cursor,
+                },
+            });
+        }
+
+        self.data_file_cursor += additional;
+        self.abs_cursor += additional;
+
+        Ok(())
+    }
+
+    /// Add sectors of silence (all zeroes)
+    fn add_gap(&mut self, sectors: u32) {
+        if let Some(entry) = self.map.last_mut()
+            && let SectorSource::Zeros = entry.source
+        {
+            // Add more sectors to the existing map entry
+            entry.sector_count += sectors;
+        } else if sectors > 0 {
+            // Start a new map entry
+            self.map.push(SectorMapEntry {
+                sector: self.abs_cursor,
+                sector_count: sectors,
+                source: SectorSource::Zeros,
+            });
+        }
+
+        self.abs_cursor += sectors;
+    }
+
+    fn add_rest_of_data_file(&mut self) -> Result<()> {
+        self.add_data_up_to(self.data_file_max)
+    }
+
+    fn build(mut self) -> Result<Vec<SectorMapEntry>> {
+        self.add_rest_of_data_file()?;
+        Ok(self.map)
+    }
 }
 
 pub struct CuesheetCdromBackend {
     cue_path: PathBuf,
     data_files: Vec<CuesheetDataFile>,
     sessions: Vec<SessionInfo>,
+    /// Map of sectors. Entries are sorted in order of increasing `sector` field.
+    /// This table maps absolute sector numbers to data files. This is NOT the
+    /// table of contents; it doesn't carry information about tracks.
+    sector_map: Vec<SectorMapEntry>,
 }
 
 enum CuesheetTrackForm {
@@ -103,16 +230,12 @@ impl CuesheetCdromBackend {
         let cue_dir = path.parent().unwrap();
         let cue_file = BufReader::new(File::open(path)?);
 
-        let mut data_files = vec![];
-        // Data files always start at time 00:02:00 (sector 150).
-        // This means there are 150 sectors located in the lead-in area which
-        // cannot be specified by the .bin/.cue format.
-        // These sectors are usually empty, but sometimes they contain various
-        // data such as CD-TEXT information.
-        let mut next_data_file_sector = LBA_START_SECTOR;
+        let mut data_files: Vec<CuesheetDataFile> = vec![];
+        let mut sector_map = SectorMapBuilder::new();
 
         let mut track_num = 0u8;
         let mut track_form = CuesheetTrackForm::Audio;
+        let mut gap_sectors = 0;
 
         let mut tracks = vec![];
 
@@ -142,11 +265,11 @@ impl CuesheetCdromBackend {
                         let sector_count =
                             data_file_len.div_ceil(RAW_SECTOR_LEN as u64).try_into()?;
                         data_files.push(CuesheetDataFile {
-                            sector: next_data_file_sector,
                             sector_count,
                             file: data_file,
                         });
-                        next_data_file_sector += sector_count;
+
+                        sector_map.start_new_data_file(data_files.len() - 1, sector_count)?;
                     }
                     "TRACK" => {
                         track_num = read_cue_word(&mut chars)
@@ -165,24 +288,30 @@ impl CuesheetCdromBackend {
                         let index_num: u8 = read_cue_word(&mut chars)
                             .ok_or_else(|| anyhow!("Invalid INDEX command"))?
                             .parse()?;
+
+                        // Index sector is relative to the current data file.
+                        let data_file_sector = read_cue_msf(&mut chars)?.to_sector();
+                        sector_map.add_data_up_to(data_file_sector)?;
+
+                        // Add pregaps/postgaps here
+                        sector_map.add_gap(gap_sectors);
+                        gap_sectors = 0;
+
                         if index_num == 1 {
                             // The track will officially begin at index 1.
-                            // Index sector is relative to the current data file.
-                            let rel_sector = read_cue_msf(&mut chars)?.to_sector();
-                            let curr_data_file = data_files
-                                .last()
-                                .ok_or_else(|| anyhow!("No data file loaded for INDEX command"))?;
                             tracks.push(TrackInfo {
                                 tno: track_num,
                                 control: match track_form {
                                     CuesheetTrackForm::Audio => AUDIO_TRACK,
                                     CuesheetTrackForm::Mode1_2352 => DATA_TRACK,
                                 },
-                                sector: curr_data_file.sector + rel_sector,
+                                sector: sector_map.abs_cursor,
                             });
-                        } else {
-                            log::warn!("track {} INDEX {} ignored", track_num, index_num);
                         }
+                    }
+                    "PREGAP" | "POSTGAP" => {
+                        let duration = read_cue_msf(&mut chars)?.to_sector();
+                        gap_sectors += duration;
                     }
                     // TODO: Support multisession bin/cue's. IsoBuster emits REM SESSION commands to indicate a new session.
                     _ => log::warn!("Unknown cuesheet command {} ignored", command),
@@ -190,25 +319,48 @@ impl CuesheetCdromBackend {
             }
         }
 
-        log::info!("Read tracks from cuesheet: {:#?}", tracks);
+        log::debug!("Read tracks from cuesheet: {:#?}", tracks);
 
-        let final_leadout = data_files
+        // In case the final track has a postgap...
+        sector_map.add_rest_of_data_file()?;
+        sector_map.add_gap(gap_sectors);
+
+        let sector_map = sector_map.build()?;
+        log::debug!("Sector map: {:#?}", sector_map);
+
+        let final_leadout = sector_map
             .last()
-            .map(|df| df.sector + df.sector_count)
+            .map(|e| e.sector + e.sector_count)
             .unwrap_or(LBA_START_SECTOR);
 
-        Ok(Self {
+        let self_ = Self {
             cue_path: path.into(),
             data_files,
             sessions: vec![SessionInfo {
                 leadout: final_leadout,
                 tracks,
             }],
-        })
+            sector_map,
+        };
+
+        let test_sector = 20934;
+        let test = self_.find_map_entry_for_sector(test_sector);
+        log::debug!("map entry for sector {}: {:#?}", test_sector, test);
+        log::debug!("sector {} is at rel sector {}", test_sector, test_sector - test.unwrap().sector);
+        let test_source = match test.unwrap().source {
+            SectorSource::DataFile{ data_file_idx: _, data_file_sector } => data_file_sector,
+            _ => unreachable!()
+        };
+        let file_sector = test_source + test_sector - test.unwrap().sector;
+        log::debug!("sector {} is at file sector {} (file offset 0x{:X})", test_sector, file_sector, file_sector * 2352);
+
+        Ok(self_)
     }
 
-    fn find_data_file_for_sector(&self, sector: u32) -> Option<&CuesheetDataFile> {
-        self.data_files.iter().rev().find(|df| df.sector <= sector)
+    fn find_map_entry_for_sector(&self, sector: u32) -> Option<&SectorMapEntry> {
+        // TODO: use partition_point?
+        let idx = self.sector_map.iter().rposition(|entry| sector >= entry.sector)?;
+        self.sector_map.get(idx)
     }
 }
 
@@ -248,17 +400,36 @@ impl CdromBackend for CuesheetCdromBackend {
     }
 
     fn read_raw_sector(&self, sector: u32) -> Result<[u8; RAW_SECTOR_LEN]> {
-        let mut result = [0; RAW_SECTOR_LEN];
-        let data_file = self
-            .find_data_file_for_sector(sector)
-            .ok_or_else(|| anyhow!("No data file contains sector {}", sector))?;
-        let rel_sector = sector - data_file.sector;
-        // It turns out you don't need a &mut File to seek and read!
-        // Just call seek and read on a `&File`. This will clobber the file cursor,
-        // so use with caution.
-        let mut data_file: &File = &data_file.file;
-        data_file.seek(SeekFrom::Start(rel_sector as u64 * RAW_SECTOR_LEN as u64))?;
-        data_file.read_exact(&mut result)?;
+        let map_entry = self
+            .find_map_entry_for_sector(sector)
+            .ok_or_else(|| anyhow!("Sector {} not found in sector map", sector))?;
+        if !(map_entry.sector..map_entry.sector + map_entry.sector_count).contains(&sector) {
+            bail!("Sector {} not found in sector map", sector);
+        }
+
+        let rel_sector = sector - map_entry.sector;
+
+        let result = match map_entry.source {
+            SectorSource::Zeros => [0; RAW_SECTOR_LEN],
+            SectorSource::DataFile {
+                data_file_idx,
+                data_file_sector,
+            } => {
+                let data_file = &self.data_files[data_file_idx];
+                let sector_in_file = data_file_sector + rel_sector;
+                // It turns out you don't need a &mut File to seek and read!
+                // Just call seek and read on a `&File`. This will clobber the file cursor,
+                // so use with caution.
+                let mut data_file: &File = &data_file.file;
+                data_file.seek(SeekFrom::Start(
+                    sector_in_file as u64 * RAW_SECTOR_LEN as u64,
+                ))?;
+                let mut result = [0; RAW_SECTOR_LEN];
+                data_file.read_exact(&mut result)?;
+                result
+            }
+        };
+
         Ok(result)
     }
 }

--- a/core/src/mac/scsi/cdrom/backends/cuesheet.rs
+++ b/core/src/mac/scsi/cdrom/backends/cuesheet.rs
@@ -93,10 +93,10 @@ enum SectorSource {
     Zeros,
     /// Sectors sourced from a data file
     DataFile {
-        /// Index of file in the data_files array
-        data_file_idx: usize,
+        /// Index of file in the `files` array
+        file_idx: usize,
         /// Sector number relative to the beginning of the file
-        data_file_sector: u32,
+        file_sector: u32,
     },
 }
 
@@ -111,11 +111,11 @@ struct SectorMapBuilder {
     /// Absolute sector number
     abs_cursor: u32,
     /// Sector number within current data file
-    data_file_cursor: u32,
+    file_cursor: u32,
     /// Max sectors in current data file
-    data_file_max: u32,
-    /// Index of current data file in the cuesheet's `data_files` array
-    data_file_idx: usize,
+    file_max: u32,
+    /// Index of current data file in the cuesheet's `files` array
+    file_idx: usize,
     map: Vec<SectorMapEntry>,
 }
 
@@ -128,38 +128,38 @@ impl SectorMapBuilder {
         // data such as CD-TEXT information.
         SectorMapBuilder {
             abs_cursor: LBA_START_SECTOR,
-            data_file_cursor: 0,
-            data_file_max: 0,
-            data_file_idx: 0,
+            file_cursor: 0,
+            file_max: 0,
+            file_idx: 0,
             map: vec![],
         }
     }
 
-    fn start_new_data_file(&mut self, idx: usize, max: u32) -> Result<()> {
+    fn start_new_file(&mut self, idx: usize, max: u32) -> Result<()> {
         // If a data file exists, add the rest of its sectors before starting the new file
-        self.add_rest_of_data_file()?;
-        self.data_file_cursor = 0;
-        self.data_file_idx = idx;
-        self.data_file_max = max;
+        self.add_rest_of_file()?;
+        self.file_cursor = 0;
+        self.file_idx = idx;
+        self.file_max = max;
 
         Ok(())
     }
 
     /// Add data sectors up to a given sector number within the data file
-    fn add_data_up_to(&mut self, up_to: u32) -> Result<()> {
-        if up_to < self.data_file_cursor {
-            bail!("Data file sector number cannot decrease");
+    fn add_file_up_to(&mut self, up_to: u32) -> Result<()> {
+        if up_to < self.file_cursor {
+            bail!("File sector number cannot decrease");
         }
 
-        if up_to > self.data_file_max {
-            bail!("Data file sector number exceeded max");
+        if up_to > self.file_max {
+            bail!("File sector number exceeded max");
         }
 
-        let additional = up_to - self.data_file_cursor;
+        let additional = up_to - self.file_cursor;
 
         if let Some(entry) = self.map.last_mut()
-            && let SectorSource::DataFile { data_file_idx, .. } = entry.source
-            && data_file_idx == self.data_file_idx
+            && let SectorSource::DataFile { file_idx, .. } = entry.source
+            && file_idx == self.file_idx
         {
             // Add more sectors to the existing map entry
             entry.sector_count += additional;
@@ -169,13 +169,13 @@ impl SectorMapBuilder {
                 sector: self.abs_cursor,
                 sector_count: additional,
                 source: SectorSource::DataFile {
-                    data_file_idx: self.data_file_idx,
-                    data_file_sector: self.data_file_cursor,
+                    file_idx: self.file_idx,
+                    file_sector: self.file_cursor,
                 },
             });
         }
 
-        self.data_file_cursor += additional;
+        self.file_cursor += additional;
         self.abs_cursor += additional;
 
         Ok(())
@@ -200,19 +200,19 @@ impl SectorMapBuilder {
         self.abs_cursor += sectors;
     }
 
-    fn add_rest_of_data_file(&mut self) -> Result<()> {
-        self.add_data_up_to(self.data_file_max)
+    fn add_rest_of_file(&mut self) -> Result<()> {
+        self.add_file_up_to(self.file_max)
     }
 
     fn build(mut self) -> Result<Vec<SectorMapEntry>> {
-        self.add_rest_of_data_file()?;
+        self.add_rest_of_file()?;
         Ok(self.map)
     }
 }
 
 pub struct CuesheetCdromBackend {
     cue_path: PathBuf,
-    data_files: Vec<CuesheetDataFile>,
+    files: Vec<CuesheetDataFile>,
     sessions: Vec<SessionInfo>,
     /// Map of sectors. Entries are sorted in order of increasing `sector` field.
     /// This table maps absolute sector numbers to data files. This is NOT the
@@ -230,7 +230,7 @@ impl CuesheetCdromBackend {
         let cue_dir = path.parent().unwrap();
         let cue_file = BufReader::new(File::open(path)?);
 
-        let mut data_files: Vec<CuesheetDataFile> = vec![];
+        let mut files: Vec<CuesheetDataFile> = vec![];
         let mut sector_map = SectorMapBuilder::new();
 
         let mut track_num = 0u8;
@@ -247,29 +247,29 @@ impl CuesheetCdromBackend {
             if let Some(command) = read_cue_word(&mut chars) {
                 match command.as_str() {
                     "FILE" => {
-                        let data_file_path = read_cue_path(&mut chars)
+                        let file_path = read_cue_path(&mut chars)
                             .ok_or_else(|| anyhow!("Failed to parse FILE command"))?;
-                        let data_file_path = cue_dir.join(Path::new(&data_file_path));
+                        let file_path = cue_dir.join(Path::new(&file_path));
 
                         let file_type = read_cue_word(&mut chars)
                             .ok_or_else(|| anyhow!("Failed to parse FILE command"))?;
                         // TODO: support WAVE?
                         if file_type != "BINARY" {
-                            bail!("Unsupported data file type `{}` in cuesheet", file_type);
+                            bail!("Unsupported file type `{}` in cuesheet", file_type);
                         }
 
-                        log::info!("Loading datafile from {}", data_file_path.to_string_lossy());
+                        log::info!("Loading file from {}", file_path.to_string_lossy());
 
-                        let data_file = File::open(data_file_path)?;
-                        let data_file_len = data_file.metadata()?.len();
+                        let file = File::open(file_path)?;
+                        let file_len = file.metadata()?.len();
                         let sector_count =
-                            data_file_len.div_ceil(RAW_SECTOR_LEN as u64).try_into()?;
-                        data_files.push(CuesheetDataFile {
+                            file_len.div_ceil(RAW_SECTOR_LEN as u64).try_into()?;
+                        files.push(CuesheetDataFile {
                             sector_count,
-                            file: data_file,
+                            file,
                         });
 
-                        sector_map.start_new_data_file(data_files.len() - 1, sector_count)?;
+                        sector_map.start_new_file(files.len() - 1, sector_count)?;
                     }
                     "TRACK" => {
                         track_num = read_cue_word(&mut chars)
@@ -289,9 +289,11 @@ impl CuesheetCdromBackend {
                             .ok_or_else(|| anyhow!("Invalid INDEX command"))?
                             .parse()?;
 
-                        // Index sector is relative to the current data file.
-                        let data_file_sector = read_cue_msf(&mut chars)?.to_sector();
-                        sector_map.add_data_up_to(data_file_sector)?;
+                        // Index sector is relative to the current data file
+                        let file_sector = read_cue_msf(&mut chars)?.to_sector();
+
+                        // Add any previous file data up to this point
+                        sector_map.add_file_up_to(file_sector)?;
 
                         // Add pregaps/postgaps here
                         sector_map.add_gap(gap_sectors);
@@ -311,6 +313,7 @@ impl CuesheetCdromBackend {
                     }
                     "PREGAP" | "POSTGAP" => {
                         let duration = read_cue_msf(&mut chars)?.to_sector();
+                        // Zeros sectors will be added to the map by the INDEX command
                         gap_sectors += duration;
                     }
                     // TODO: Support multisession bin/cue's. IsoBuster emits REM SESSION commands to indicate a new session.
@@ -322,7 +325,7 @@ impl CuesheetCdromBackend {
         log::debug!("Read tracks from cuesheet: {:#?}", tracks);
 
         // In case the final track has a postgap...
-        sector_map.add_rest_of_data_file()?;
+        sector_map.add_rest_of_file()?;
         sector_map.add_gap(gap_sectors);
 
         let sector_map = sector_map.build()?;
@@ -335,7 +338,7 @@ impl CuesheetCdromBackend {
 
         Ok(Self {
             cue_path: path.into(),
-            data_files,
+            files,
             sessions: vec![SessionInfo {
                 leadout: final_leadout,
                 tracks,
@@ -399,20 +402,20 @@ impl CdromBackend for CuesheetCdromBackend {
         let result = match map_entry.source {
             SectorSource::Zeros => [0; RAW_SECTOR_LEN],
             SectorSource::DataFile {
-                data_file_idx,
-                data_file_sector,
+                file_idx,
+                file_sector,
             } => {
-                let data_file = &self.data_files[data_file_idx];
-                let sector_in_file = data_file_sector + rel_sector;
+                let file = &self.files[file_idx];
+                let sector_in_file = file_sector + rel_sector;
                 // It turns out you don't need a &mut File to seek and read!
                 // Just call seek and read on a `&File`. This will clobber the file cursor,
                 // so use with caution.
-                let mut data_file: &File = &data_file.file;
-                data_file.seek(SeekFrom::Start(
+                let mut file: &File = &file.file;
+                file.seek(SeekFrom::Start(
                     sector_in_file as u64 * RAW_SECTOR_LEN as u64,
                 ))?;
                 let mut result = [0; RAW_SECTOR_LEN];
-                data_file.read_exact(&mut result)?;
+                file.read_exact(&mut result)?;
                 result
             }
         };

--- a/core/src/mac/scsi/cdrom/backends/cuesheet.rs
+++ b/core/src/mac/scsi/cdrom/backends/cuesheet.rs
@@ -126,7 +126,7 @@ impl SectorMapBuilder {
         // cannot be specified by the .bin/.cue format.
         // These sectors are usually empty, but sometimes they contain various
         // data such as CD-TEXT information.
-        SectorMapBuilder {
+        Self {
             abs_cursor: LBA_START_SECTOR,
             file_cursor: 0,
             file_max: 0,
@@ -184,7 +184,7 @@ impl SectorMapBuilder {
     /// Add sectors of silence (all zeroes)
     fn add_gap(&mut self, sectors: u32) {
         if let Some(entry) = self.map.last_mut()
-            && let SectorSource::Zeros = entry.source
+            && matches!(entry.source, SectorSource::Zeros)
         {
             // Add more sectors to the existing map entry
             entry.sector_count += sectors;
@@ -262,12 +262,8 @@ impl CuesheetCdromBackend {
 
                         let file = File::open(file_path)?;
                         let file_len = file.metadata()?.len();
-                        let sector_count =
-                            file_len.div_ceil(RAW_SECTOR_LEN as u64).try_into()?;
-                        files.push(CuesheetDataFile {
-                            sector_count,
-                            file,
-                        });
+                        let sector_count = file_len.div_ceil(RAW_SECTOR_LEN as u64).try_into()?;
+                        files.push(CuesheetDataFile { sector_count, file });
 
                         sector_map.start_new_file(files.len() - 1, sector_count)?;
                     }
@@ -322,7 +318,7 @@ impl CuesheetCdromBackend {
             }
         }
 
-        log::debug!("Read tracks from cuesheet: {:#?}", tracks);
+        log::debug!("Tracks: {:#?}", tracks);
 
         // In case the final track has a postgap...
         sector_map.add_rest_of_file()?;
@@ -349,7 +345,10 @@ impl CuesheetCdromBackend {
 
     fn find_map_entry_for_sector(&self, sector: u32) -> Option<&SectorMapEntry> {
         // TODO: use partition_point?
-        let idx = self.sector_map.iter().rposition(|entry| sector >= entry.sector)?;
+        let idx = self
+            .sector_map
+            .iter()
+            .rposition(|entry| sector >= entry.sector)?;
         self.sector_map.get(idx)
     }
 }

--- a/core/src/mac/scsi/cdrom/backends/iso.rs
+++ b/core/src/mac/scsi/cdrom/backends/iso.rs
@@ -1,8 +1,8 @@
-use anyhow::{bail, Result};
+use anyhow::{Result, bail};
 use std::path::Path;
 
 use crate::mac::scsi::{
-    cdrom::{CdromBackend, SessionInfo, TrackInfo, DATA_TRACK, LBA_START_SECTOR, RAW_SECTOR_LEN},
+    cdrom::{CdromBackend, DATA_TRACK, LBA_START_SECTOR, RAW_SECTOR_LEN, SessionInfo, TrackInfo},
     disk_image::DiskImage,
 };
 

--- a/core/src/mac/scsi/cdrom/mod.rs
+++ b/core/src/mac/scsi/cdrom/mod.rs
@@ -440,18 +440,21 @@ impl ScsiTargetCdrom {
         }
 
         let samples = backend.read_raw_sector(self.audio_pos);
-        if let Ok(samples) = samples {
-            // FIXME: can we avoid converting to float by setting up a signed 16-bit PCM audio sink?
-            let mut out_samples = [0.0; RAW_SECTOR_LEN / 2]; // 16-bit samples
-            for i in 0..RAW_SECTOR_LEN / 2 {
-                let sample = i16::from_le_bytes(samples[2 * i..][..2].try_into().unwrap());
-                out_samples[i] = sample as f32 / 32768.0 * self.audio_volume as f32 / 255.0;
+        match samples {
+            Ok(samples) => {
+                // FIXME: can we avoid converting to float by setting up a signed 16-bit PCM audio sink?
+                let mut out_samples = [0.0; RAW_SECTOR_LEN / 2]; // 16-bit samples
+                for i in 0..RAW_SECTOR_LEN / 2 {
+                    let sample = i16::from_le_bytes(samples[2 * i..][..2].try_into().unwrap());
+                    out_samples[i] = sample as f32 / 32768.0 * self.audio_volume as f32 / 255.0;
+                }
+    
+                audio_sink.send(Box::new(out_samples))?;
             }
-
-            audio_sink.send(Box::new(out_samples))?;
-
-            self.audio_pos += 1;
+            Err(e) => log::warn!("Failed to read raw samples from sector {}: {}", self.audio_pos, e)
         }
+
+        self.audio_pos += 1;
 
         Ok(())
     }

--- a/core/src/mac/scsi/cdrom/mod.rs
+++ b/core/src/mac/scsi/cdrom/mod.rs
@@ -413,6 +413,8 @@ impl ScsiTargetCdrom {
     fn eject_media(&mut self) {
         self.event_eject.set();
         self.backend = None;
+        self.audio_state = AudioState::Stopped;
+        self.audio_pos = LBA_START_SECTOR;
     }
 
     /// Read a frame of CD audio and send it to the audio sink.

--- a/core/src/mac/scsi/cdrom/mod.rs
+++ b/core/src/mac/scsi/cdrom/mod.rs
@@ -2,13 +2,13 @@
 
 mod backends;
 
-use anyhow::{anyhow, bail, Result};
+use anyhow::{Result, anyhow, bail};
 use serde::{Deserialize, Serialize};
 use std::path::Path;
 
 use crate::debuggable::Debuggable;
-use crate::emulator::comm::EmulatorSpeed;
 use crate::emulator::EmuContext;
+use crate::emulator::comm::EmulatorSpeed;
 use crate::mac::macii::bus::CLOCK_SPEED;
 use crate::mac::scsi::cdrom::backends::cuesheet::CuesheetCdromBackend;
 use crate::mac::scsi::cdrom::backends::iso::IsoCdromBackend;
@@ -17,21 +17,21 @@ use crate::mac::scsi::{
     ASC_ILLEGAL_MODE_FOR_THIS_TRACK, ASC_INVALID_COMMAND, ASC_LOGICAL_BLOCK_ADDRESS_OUT_OF_RANGE,
     ASC_UNRECOVERED_READ_ERROR,
 };
-use crate::renderer::{AudioProvider, AudioSink, AUDIO_BUFFER_SAMPLES};
+use crate::renderer::{AUDIO_BUFFER_SAMPLES, AudioProvider, AudioSink};
 use crate::tickable::Ticks;
 use crate::types::LatchingEvent;
 
-use super::disk_image::{DiskImage, FileDiskImage};
-use super::target::ScsiTarget;
-use super::target::ScsiTargetEvent;
-use super::target::ScsiTargetType;
-use super::ScsiCmdResult;
 use super::ASC_INVALID_FIELD_IN_CDB;
 use super::ASC_MEDIUM_NOT_PRESENT;
 use super::CC_KEY_ILLEGAL_REQUEST;
 use super::CC_KEY_MEDIUM_ERROR;
 use super::STATUS_CHECK_CONDITION;
 use super::STATUS_GOOD;
+use super::ScsiCmdResult;
+use super::disk_image::{DiskImage, FileDiskImage};
+use super::target::ScsiTarget;
+use super::target::ScsiTargetEvent;
+use super::target::ScsiTargetType;
 
 // CD-ROM protocol Documentation:
 //
@@ -450,10 +450,14 @@ impl ScsiTargetCdrom {
                     let sample = i16::from_le_bytes(samples[2 * i..][..2].try_into().unwrap());
                     out_samples[i] = sample as f32 / 32768.0 * self.audio_volume as f32 / 255.0;
                 }
-    
+
                 audio_sink.send(Box::new(out_samples))?;
             }
-            Err(e) => log::warn!("Failed to read raw samples from sector {}: {}", self.audio_pos, e)
+            Err(e) => log::warn!(
+                "Failed to read raw samples from sector {}: {}",
+                self.audio_pos,
+                e
+            ),
         }
 
         self.audio_pos += 1;
@@ -621,7 +625,7 @@ impl ScsiTarget for ScsiTargetCdrom {
                 // return mode page data after byte 26.
                 let mut data = vec![0; 0x18];
                 data[2] = 1; // Audio Play
-                             // TODO: support more features such as Mode2 sectors, multiple sessions, etc.
+                // TODO: support more features such as Mode2 sectors, multiple sessions, etc.
                 data[4] = (0b001 << 5) | (1 << 3); // Tray type loading mechanism; Eject
                 data[8..=9].copy_from_slice(&256u16.to_be_bytes()); // Number of Volume Levels Supported
 

--- a/core/src/mac/scsi/controller.rs
+++ b/core/src/mac/scsi/controller.rs
@@ -3,7 +3,7 @@
 use std::collections::VecDeque;
 use std::path::{Path, PathBuf};
 
-use anyhow::{bail, Result};
+use anyhow::{Result, bail};
 
 use log::*;
 use num_derive::FromPrimitive;
@@ -17,6 +17,8 @@ use crate::bus::{Address, BusMember};
 use crate::dbgprop_byte;
 use crate::debuggable::Debuggable;
 use crate::emulator::EmuContext;
+use crate::mac::scsi::STATUS_GOOD;
+use crate::mac::scsi::ScsiCmdResult;
 use crate::mac::scsi::cdrom::ScsiTargetCdrom;
 use crate::mac::scsi::disk::ScsiTargetDisk;
 use crate::mac::scsi::disk_image::DiskImage;
@@ -26,8 +28,6 @@ use crate::mac::scsi::scsi_cmd_len;
 use crate::mac::scsi::target::ScsiTarget;
 use crate::mac::scsi::target::ScsiTargetType;
 use crate::mac::scsi::toolbox::BlueSCSI;
-use crate::mac::scsi::ScsiCmdResult;
-use crate::mac::scsi::STATUS_GOOD;
 use crate::renderer::AudioProvider;
 use crate::tickable::{Tickable, Ticks};
 use crate::types::LatchingEvent;

--- a/core/src/mac/scsi/disk.rs
+++ b/core/src/mac/scsi/disk.rs
@@ -1,16 +1,16 @@
 //! SCSI hard disk drive (block device)
 
-use anyhow::{bail, Result};
+use anyhow::{Result, bail};
 use serde::{Deserialize, Serialize};
 use std::path::Path;
 
 use crate::debuggable::Debuggable;
+use crate::mac::scsi::STATUS_CHECK_CONDITION;
+use crate::mac::scsi::STATUS_GOOD;
+use crate::mac::scsi::ScsiCmdResult;
 use crate::mac::scsi::disk_image::{DiskImage, FileDiskImage};
 use crate::mac::scsi::target::ScsiTargetType;
 use crate::mac::scsi::target::{ScsiTarget, ScsiTargetCommon};
-use crate::mac::scsi::ScsiCmdResult;
-use crate::mac::scsi::STATUS_CHECK_CONDITION;
-use crate::mac::scsi::STATUS_GOOD;
 
 pub const DISK_BLOCKSIZE: usize = 512;
 
@@ -85,7 +85,7 @@ impl ScsiTarget for ScsiTargetDisk {
 
         // 0 Peripheral qualifier (5-7), peripheral device type (4-0)
         result[0] = 0; // Magnetic disk
-                       // Device Type Modifier
+        // Device Type Modifier
         result[1] = 0;
 
         // SCSI version compliance

--- a/core/src/mac/scsi/disk_image.rs
+++ b/core/src/mac/scsi/disk_image.rs
@@ -1,6 +1,6 @@
 //! SCSI disk image abstraction
 
-use anyhow::{bail, Context, Result};
+use anyhow::{Context, Result, bail};
 #[cfg(feature = "mmap")]
 use memmap2::MmapMut;
 use std::path::{Path, PathBuf};

--- a/core/src/mac/scsi/ethernet.rs
+++ b/core/src/mac/scsi/ethernet.rs
@@ -1,14 +1,14 @@
 //! Daynaport SCSI Ethernet adapter
 
 use crate::debuggable::{Debuggable, DebuggableProperties};
-use crate::mac::scsi::target::{ScsiTarget, ScsiTargetCommon, ScsiTargetEvent, ScsiTargetType};
-use crate::mac::scsi::ScsiCmdResult;
 use crate::mac::scsi::STATUS_CHECK_CONDITION;
 use crate::mac::scsi::STATUS_GOOD;
+use crate::mac::scsi::ScsiCmdResult;
+use crate::mac::scsi::target::{ScsiTarget, ScsiTargetCommon, ScsiTargetEvent, ScsiTargetType};
 use crate::util::{deserialize_arc_rwlock, serialize_arc_rwlock};
 
 use anyhow::Result;
-use binrw::{binrw, BinWrite};
+use binrw::{BinWrite, binrw};
 #[cfg(any(
     feature = "ethernet_raw",
     all(feature = "ethernet_tap", target_os = "linux")
@@ -278,94 +278,98 @@ impl ScsiTargetEthernet {
                 } else {
                     t_emu_mac.into()
                 };
-                std::thread::spawn(move || loop {
-                    match physical_rx.next() {
-                        Ok(packet) => {
-                            // Squelch echos and filter on packets destined for us
-                            let mut packet = packet.to_vec();
-                            let Some(mut ethpacket) =
-                                pnet::packet::ethernet::MutableEthernetPacket::new(&mut packet)
-                            else {
-                                log::warn!("Dropped RX invalid packet: {:02X?}", packet);
-                                continue;
-                            };
-                            let dest = ethpacket.get_destination();
-                            let src = ethpacket.get_source();
-                            if (dest != t_physical_mac && !dest.is_broadcast())
-                                || src == t_physical_mac
-                            {
-                                continue;
-                            }
-
-                            // Rewrite MAC-addresses
-                            if REWRITE_MACS && dest == t_physical_mac {
-                                ethpacket.set_destination(t_emu_mac.into());
-                            }
-
-                            //log::debug!("Physical RX: {:?} {:02X?}", &ethpacket, &packet);
-
-                            match bridge_tx.try_send(packet.to_vec()) {
-                                Ok(_) => {}
-                                Err(TrySendError::Disconnected(_)) => {
-                                    log::info!("Bridge terminated (bridge_tx closed)");
-                                    return;
+                std::thread::spawn(move || {
+                    loop {
+                        match physical_rx.next() {
+                            Ok(packet) => {
+                                // Squelch echos and filter on packets destined for us
+                                let mut packet = packet.to_vec();
+                                let Some(mut ethpacket) =
+                                    pnet::packet::ethernet::MutableEthernetPacket::new(&mut packet)
+                                else {
+                                    log::warn!("Dropped RX invalid packet: {:02X?}", packet);
+                                    continue;
+                                };
+                                let dest = ethpacket.get_destination();
+                                let src = ethpacket.get_source();
+                                if (dest != t_physical_mac && !dest.is_broadcast())
+                                    || src == t_physical_mac
+                                {
+                                    continue;
                                 }
-                                Err(TrySendError::Full(_)) => {
-                                    log::error!("bridge_tx queue overflow");
+
+                                // Rewrite MAC-addresses
+                                if REWRITE_MACS && dest == t_physical_mac {
+                                    ethpacket.set_destination(t_emu_mac.into());
+                                }
+
+                                //log::debug!("Physical RX: {:?} {:02X?}", &ethpacket, &packet);
+
+                                match bridge_tx.try_send(packet.to_vec()) {
+                                    Ok(_) => {}
+                                    Err(TrySendError::Disconnected(_)) => {
+                                        log::info!("Bridge terminated (bridge_tx closed)");
+                                        return;
+                                    }
+                                    Err(TrySendError::Full(_)) => {
+                                        log::error!("bridge_tx queue overflow");
+                                    }
                                 }
                             }
-                        }
-                        Err(e) => {
-                            log::info!("Bridge terminated (physical_rx closed: {})", e);
-                            return;
+                            Err(e) => {
+                                log::info!("Bridge terminated (physical_rx closed: {})", e);
+                                return;
+                            }
                         }
                     }
                 });
                 // Virtual TX -> Physical TX
-                std::thread::spawn(move || loop {
-                    use pnet::packet::{MutablePacket, Packet};
+                std::thread::spawn(move || {
+                    loop {
+                        use pnet::packet::{MutablePacket, Packet};
 
-                    match bridge_rx.recv() {
-                        Ok(mut packet) => {
-                            let Some(mut ethpacket) =
-                                pnet::packet::ethernet::MutableEthernetPacket::new(&mut packet)
-                            else {
-                                log::warn!("Dropped TX invalid packet: {:02X?}", packet);
-                                continue;
-                            };
-                            if REWRITE_MACS && ethpacket.get_source() == t_emu_mac {
-                                ethpacket.set_source(t_physical_mac);
-                            }
-                            if REWRITE_MACS
-                                && ethpacket.get_ethertype()
-                                    == pnet::packet::ethernet::EtherTypes::Arp
-                            {
-                                if let Some(mut arppacket) =
-                                    pnet::packet::arp::MutableArpPacket::new(
-                                        ethpacket.payload_mut(),
-                                    )
+                        match bridge_rx.recv() {
+                            Ok(mut packet) => {
+                                let Some(mut ethpacket) =
+                                    pnet::packet::ethernet::MutableEthernetPacket::new(&mut packet)
+                                else {
+                                    log::warn!("Dropped TX invalid packet: {:02X?}", packet);
+                                    continue;
+                                };
+                                if REWRITE_MACS && ethpacket.get_source() == t_emu_mac {
+                                    ethpacket.set_source(t_physical_mac);
+                                }
+                                if REWRITE_MACS
+                                    && ethpacket.get_ethertype()
+                                        == pnet::packet::ethernet::EtherTypes::Arp
                                 {
-                                    arppacket.set_sender_hw_addr(t_physical_mac);
+                                    if let Some(mut arppacket) =
+                                        pnet::packet::arp::MutableArpPacket::new(
+                                            ethpacket.payload_mut(),
+                                        )
+                                    {
+                                        arppacket.set_sender_hw_addr(t_physical_mac);
+                                    }
+                                }
+
+                                // Minimum frame size
+                                //if out_packet.len() < 64 {
+                                //    out_packet.resize(64, 0);
+                                //}
+                                //log::debug!("Physical TX: {:02X?}", &ethpacket);
+
+                                match physical_tx.send_to(ethpacket.packet(), None).unwrap() {
+                                    Ok(_) => {}
+                                    Err(e) => {
+                                        log::info!("Bridge terminated (physical_tx closed: {})", e);
+                                        return;
+                                    }
                                 }
                             }
-
-                            // Minimum frame size
-                            //if out_packet.len() < 64 {
-                            //    out_packet.resize(64, 0);
-                            //}
-                            //log::debug!("Physical TX: {:02X?}", &ethpacket);
-
-                            match physical_tx.send_to(ethpacket.packet(), None).unwrap() {
-                                Ok(_) => {}
-                                Err(e) => {
-                                    log::info!("Bridge terminated (physical_tx closed: {})", e);
-                                    return;
-                                }
+                            Err(e) => {
+                                log::info!("Bridge terminated (bridge_rx closed: {})", e);
+                                return;
                             }
-                        }
-                        Err(e) => {
-                            log::info!("Bridge terminated (bridge_rx closed: {})", e);
-                            return;
                         }
                     }
                 });
@@ -561,8 +565,8 @@ impl ScsiTargetEthernet {
 
     fn start_pcap_capture<P: AsRef<Path>>(&mut self, filename: P) -> Result<()> {
         use std::io::Write;
-        use std::sync::atomic::AtomicUsize;
         use std::sync::Mutex;
+        use std::sync::atomic::AtomicUsize;
 
         if self.pcap_capture.is_some() {
             anyhow::bail!("Capture already active");

--- a/core/src/mac/scsi/target.rs
+++ b/core/src/mac/scsi/target.rs
@@ -2,16 +2,16 @@
 
 use std::path::Path;
 
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 use serde::{Deserialize, Serialize};
 
 use crate::debuggable::Debuggable;
 use crate::emulator::EmuContext;
 use crate::mac::scsi::disk_image::DiskImage;
 use crate::mac::scsi::{
-    ScsiCmdResult, ASC_INVALID_FIELD_IN_CDB, ASC_LOGICAL_BLOCK_ADDRESS_OUT_OF_RANGE,
-    ASC_MEDIUM_NOT_PRESENT, ASC_PARAMETER_LIST_LENGTH_ERROR, CC_KEY_ILLEGAL_REQUEST,
-    CC_KEY_MEDIUM_ERROR, STATUS_CHECK_CONDITION, STATUS_GOOD,
+    ASC_INVALID_FIELD_IN_CDB, ASC_LOGICAL_BLOCK_ADDRESS_OUT_OF_RANGE, ASC_MEDIUM_NOT_PRESENT,
+    ASC_PARAMETER_LIST_LENGTH_ERROR, CC_KEY_ILLEGAL_REQUEST, CC_KEY_MEDIUM_ERROR,
+    STATUS_CHECK_CONDITION, STATUS_GOOD, ScsiCmdResult,
 };
 use crate::renderer::AudioProvider;
 use crate::tickable::Ticks;
@@ -138,20 +138,20 @@ pub(crate) trait ScsiTarget: Send + Debuggable {
     }
 
     fn check_lba_within_capacity(&mut self, lba: u32) -> bool {
-        if let Some(capacity) = self.capacity() {
-            if lba as usize >= capacity / self.blocksize().unwrap() {
-                log::error!(
-                    "Seeking beyond disk, lba: {}, capacity: {}, blocksize: {}",
-                    lba,
-                    capacity,
-                    self.blocksize().unwrap()
-                );
-                self.common().set_cc(
-                    CC_KEY_ILLEGAL_REQUEST,
-                    ASC_LOGICAL_BLOCK_ADDRESS_OUT_OF_RANGE,
-                );
-                return false;
-            }
+        if let Some(capacity) = self.capacity()
+            && lba as usize >= capacity / self.blocksize().unwrap()
+        {
+            log::error!(
+                "Seeking beyond disk, lba: {}, capacity: {}, blocksize: {}",
+                lba,
+                capacity,
+                self.blocksize().unwrap()
+            );
+            self.common().set_cc(
+                CC_KEY_ILLEGAL_REQUEST,
+                ASC_LOGICAL_BLOCK_ADDRESS_OUT_OF_RANGE,
+            );
+            return false;
         }
         true
     }
@@ -466,9 +466,9 @@ pub(crate) trait ScsiTarget: Send + Debuggable {
                 result.push(0);
                 result.push(self.ms_media_type()); // Medium type
                 result.push(self.ms_device_specific()); // Device-specific parameter
-                                                        // TODO: Support LONGLBA (required if LLBAA != 0?)
+                // TODO: Support LONGLBA (required if LLBAA != 0?)
                 result.push(0); // Reserved/LONGLBA
-                                // Block descriptor length
+                // Block descriptor length
                 result.extend_from_slice(&(if dbd { 0u16 } else { 8u16 }).to_be_bytes());
 
                 if !dbd {

--- a/core/src/mac/scsi/toolbox.rs
+++ b/core/src/mac/scsi/toolbox.rs
@@ -13,7 +13,7 @@ use std::path::PathBuf;
 
 use log::*;
 
-use super::{ScsiCmdResult, STATUS_CHECK_CONDITION, STATUS_GOOD};
+use super::{STATUS_CHECK_CONDITION, STATUS_GOOD, ScsiCmdResult};
 
 const MAX_FILE_PATH: usize = 32; // Max Macintosh File name length
 
@@ -167,14 +167,14 @@ impl BlueSCSI {
 
         if let Some(file) = &mut self.file {
             let mut buffer = vec![0; bytes_requested as usize];
-            if file.seek(SeekFrom::Start(offset * block_size)).is_ok() {
-                if let Ok(bytes_read) = file.read(&mut buffer) {
-                    buffer.truncate(bytes_read);
-                    if bytes_read == 0 {
-                        self.file = None;
-                    }
-                    return ScsiCmdResult::DataIn(buffer);
+            if file.seek(SeekFrom::Start(offset * block_size)).is_ok()
+                && let Ok(bytes_read) = file.read(&mut buffer)
+            {
+                buffer.truncate(bytes_read);
+                if bytes_read == 0 {
+                    self.file = None;
                 }
+                return ScsiCmdResult::DataIn(buffer);
             }
         }
         ScsiCmdResult::Status(STATUS_CHECK_CONDITION)
@@ -185,17 +185,17 @@ impl BlueSCSI {
             return ScsiCmdResult::Status(STATUS_CHECK_CONDITION);
         };
         if let Some(data) = outdata {
-            if let Some(pos) = data.iter().position(|&b| b == 0) {
-                if let Ok(name) = std::str::from_utf8(&data[..pos]) {
-                    let path = shared_dir.join(name);
-                    match File::create(path) {
-                        Ok(f) => {
-                            self.file = Some(f);
-                            return ScsiCmdResult::Status(STATUS_GOOD);
-                        }
-                        Err(e) => {
-                            error!("Failed to create file: {}", e);
-                        }
+            if let Some(pos) = data.iter().position(|&b| b == 0)
+                && let Ok(name) = std::str::from_utf8(&data[..pos])
+            {
+                let path = shared_dir.join(name);
+                match File::create(path) {
+                    Ok(f) => {
+                        self.file = Some(f);
+                        return ScsiCmdResult::Status(STATUS_GOOD);
+                    }
+                    Err(e) => {
+                        error!("Failed to create file: {}", e);
                     }
                 }
             }
@@ -236,10 +236,10 @@ impl BlueSCSI {
 
     /// Match BlueSCSI behavior: no data phase, go directly to status
     fn send_file_end(&mut self) -> ScsiCmdResult {
-        if let Some(file) = self.file.take() {
-            if file.sync_all().is_ok() {
-                return ScsiCmdResult::Status(STATUS_GOOD);
-            }
+        if let Some(file) = self.file.take()
+            && file.sync_all().is_ok()
+        {
+            return ScsiCmdResult::Status(STATUS_GOOD);
         }
         ScsiCmdResult::Status(STATUS_CHECK_CONDITION)
     }

--- a/core/src/mac/serial_bridge.rs
+++ b/core/src/mac/serial_bridge.rs
@@ -84,10 +84,10 @@ pub mod pty {
     use std::fs::File;
     use std::os::fd::{AsRawFd, FromRawFd, OwnedFd};
 
-    use nix::fcntl::{fcntl, FcntlArg, OFlag};
+    use nix::fcntl::{FcntlArg, OFlag, fcntl};
     use nix::libc;
-    use nix::pty::{openpty, OpenptyResult};
-    use nix::sys::termios::{cfmakeraw, tcsetattr, SetArg};
+    use nix::pty::{OpenptyResult, openpty};
+    use nix::sys::termios::{SetArg, cfmakeraw, tcsetattr};
 
     pub struct PtyBridge {
         master: OwnedFd,

--- a/core/src/mac/swim/ism.rs
+++ b/core/src/mac/swim/ism.rs
@@ -301,6 +301,7 @@ impl Swim {
             //    reg,
             //    result.unwrap()
             //);
+            #[allow(clippy::let_and_return)]
             result
         } else {
             error!("Unknown ISM register read {:04X}", offset);

--- a/core/src/mac/swim/mod.rs
+++ b/core/src/mac/swim/mod.rs
@@ -9,7 +9,7 @@ pub mod iwm;
 
 use std::collections::VecDeque;
 
-use anyhow::{bail, Result};
+use anyhow::{Result, bail};
 use ism::{IsmError, IsmSetup, IsmStatus};
 
 use drive::{DriveType, FloppyDrive};
@@ -220,11 +220,7 @@ impl Swim {
             if self.ism_mode.drive2_enable() {
                 1
             } else if self.ism_mode.drive1_enable() {
-                if self.intdrive {
-                    2
-                } else {
-                    0
-                }
+                if self.intdrive { 2 } else { 0 }
             } else {
                 // ???
                 0
@@ -320,14 +316,14 @@ impl Tickable for Swim {
             if eject_ticks < self.cycles {
                 self.get_selected_drive_mut().eject();
             }
-        } else if !self.lstrb {
-            if let Some(eject_ticks) = self.get_selected_drive().ejecting {
-                log::debug!(
-                    "Eject strobe too short ({} cycles)",
-                    eject_ticks - self.cycles
-                );
-                self.get_selected_drive_mut().ejecting = None;
-            }
+        } else if !self.lstrb
+            && let Some(eject_ticks) = self.get_selected_drive().ejecting
+        {
+            log::debug!(
+                "Eject strobe too short ({} cycles)",
+                eject_ticks - self.cycles
+            );
+            self.get_selected_drive_mut().ejecting = None;
         }
 
         if self.get_selected_drive().is_running() {

--- a/core/src/mac/via.rs
+++ b/core/src/mac/via.rs
@@ -9,8 +9,8 @@ use anyhow::Result;
 use proc_bitfield::bitfield;
 use serde::{Deserialize, Serialize};
 
-use super::adb::AdbTransceiver;
 use super::MacModel;
+use super::adb::AdbTransceiver;
 
 /// Counter at which to trigger the one second interrupt
 /// (counted on the E Clock)
@@ -454,10 +454,10 @@ impl BusMember<Address> for Via {
                 );
                 self.b_in.set_rtcdata(rtcin);
 
-                if self.model.has_adb() {
-                    if let Some(b) = self.adb.io(self.b_out.adb_st0(), self.b_out.adb_st1()) {
-                        self.kbdshift_in = b;
-                    }
+                if self.model.has_adb()
+                    && let Some(b) = self.adb.io(self.b_out.adb_st0(), self.b_out.adb_st1())
+                {
+                    self.kbdshift_in = b;
                 }
 
                 Some(())


### PR DESCRIPTION
This PR adds support for PREGAP and POSTGAP commands in cuesheets. These commands add periods of silence which are omitted from the binary file.

I also attempt to address #274 , but it is not fixed. This issue seems to be caused by an error in either the rip or the original CD; I'm investigating further.

Why is the PR so big? I switched to Rust 2024 edition because a chained "if let" statement was too enticing. Unfortunately, cargo fmt runs on different rules in 2024 edition, and cargo clippy demanded more tweaks. Cargo fmt and cargo clippy are all clean now. All the cargo fmt and cargo clippy changes have been gathered into the last commit -- everything else is CD-ROM stuff.