### PR TITLE
Support mounting a physical CD-ROM drive on Windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4976,6 +4976,8 @@ dependencies = [
  "tun",
  "typetag",
  "unicode-normalization",
+ "windows 0.62.2",
+ "windows-result 0.4.1",
  "zstd",
 ]
 

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -76,3 +76,17 @@ image = { version = "0.25", default-features = false, features = ["png"], option
 
 [target.'cfg(unix)'.dependencies]
 nix = { version = "0.29", features = ["term", "fs"] }
+
+[target.'cfg(windows)'.dependencies]
+windows = {
+    version = "0.62.2",
+    features = [
+        "Win32_Foundation",
+        "Win32_Devices_Cdrom",
+        "Win32_Storage_FileSystem",
+        "Win32_System_IO",
+        "Win32_System_Ioctl",
+        "Win32_System_WindowsProgramming",
+    ]
+}
+windows-result = "0.4.1"

--- a/core/src/mac/scsi/cdrom/backends/cuesheet.rs
+++ b/core/src/mac/scsi/cdrom/backends/cuesheet.rs
@@ -21,7 +21,7 @@ use crate::mac::scsi::{
     CC_KEY_MEDIUM_ERROR,
     cdrom::{
         AUDIO_FRAMES_PER_SEC, AUDIO_FRAMES_PER_SECTOR, AUDIO_TRACK, CdromBackend, CdromError,
-        DATA_TRACK, LBA_START_SECTOR, Msf, RAW_SECTOR_LEN, RawSector, SessionInfo, TrackInfo,
+        DATA_TRACK, LBA_START_SECTOR, Msf, QSub, RAW_SECTOR_LEN, RawSector, SessionInfo, TrackInfo,
         get_track_at_sector,
     },
 };
@@ -795,9 +795,91 @@ impl CuesheetCdromBackend {
             .get(idx)
             .filter(|e| (e.sector..e.sector + e.sector_count).contains(&sector))
     }
+
+    fn read_raw_sector(&self, sector: u32) -> Result<RawSector, CdromError> {
+        let map_entry = self
+            .find_map_entry_for_sector(sector)
+            .ok_or_else(|| anyhow!("Sector {} not found in sector map", sector))?;
+
+        let rel_sector = sector - map_entry.sector;
+
+        let track = get_track_at_sector(&self.tracks, sector)
+            .ok_or_else(|| anyhow!("No track found at sector {}", sector))?;
+        if sector >= self.sessions[track.session as usize - 1].leadout {
+            return Err(anyhow!("Sector {} was past the lead-out", sector).into());
+        }
+
+        let data = match map_entry.source {
+            SectorSource::Zeros => [0; RAW_SECTOR_LEN],
+            SectorSource::BinaryFile {
+                file_idx,
+                file_offset,
+                format,
+            } => {
+                // It turns out you don't need a &mut File to seek and read!
+                // Just call seek and read on a `&File`. This will clobber the file cursor,
+                // so use with caution.
+                let mut file: &File = &self.binary_files[file_idx];
+                file.seek(SeekFrom::Start(
+                    file_offset + rel_sector as u64 * format.bytes_per_sector(),
+                ))
+                .map_err(|e| anyhow!(e))?;
+
+                match format {
+                    BinarySourceFormat::Raw2352 => {
+                        let mut result = [0u8; RAW_SECTOR_LEN];
+                        file.read_exact(&mut result).map_err(|e| anyhow!(e))?;
+                        result
+                    }
+                    BinarySourceFormat::Mode1_2048 => {
+                        // Reconstruct Mode 1 sector from 2048-byte user data.
+                        // Only the most important fields are filled.
+                        let mut result = [0u8; RAW_SECTOR_LEN];
+                        // Sync
+                        result[0..12]
+                            .copy_from_slice(b"\x00\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x00");
+                        // Mode
+                        result[15] = 1;
+                        // User data
+                        file.read_exact(&mut result[16..][..2048])
+                            .map_err(|e| anyhow!(e))?;
+                        // TODO: fill out more fields?
+                        result
+                    }
+                }
+            }
+            SectorSource::AudioFile {
+                file_idx,
+                timestamp_in_sectors,
+            } => {
+                let mut file = self.audio_files[file_idx].borrow_mut();
+
+                let ts = (timestamp_in_sectors as u64 + rel_sector as u64)
+                    * AUDIO_FRAMES_PER_SECTOR as u64;
+                let samples = file.read_frames(ts, AUDIO_FRAMES_PER_SECTOR)?;
+
+                let mut result = [0u8; RAW_SECTOR_LEN];
+                for (s, out) in samples.into_iter().zip(result.as_chunks_mut::<2>().0) {
+                    out.copy_from_slice(&s.to_le_bytes());
+                }
+
+                result
+            }
+        };
+
+        Ok(RawSector {
+            data,
+            // TODO: use correct INDEX (should be 0 during pre-gap)
+            qsub: QSub::new_mode1(track.control, track.tno, 1, sector, track.sector),
+        })
+    }
 }
 
 impl CdromBackend for CuesheetCdromBackend {
+    fn check_media(&mut self) -> Result<(), CdromError> {
+        Ok(())
+    }
+
     fn byte_len(&self) -> usize {
         // To find the capacity, treat each sector (except the lead-in) as a block
         // containing 2048 bytes.
@@ -821,7 +903,7 @@ impl CdromBackend for CuesheetCdromBackend {
         while result.len() < length {
             let raw_sector = self.read_raw_sector(sector)?;
 
-            if raw_sector.control != DATA_TRACK {
+            if !raw_sector.qsub.is_data() {
                 log::warn!("Tried to read bytes from non-data sector {}", sector);
                 return Err(CdromError::CheckCondition(
                     CC_KEY_ILLEGAL_REQUEST,
@@ -908,78 +990,7 @@ impl CdromBackend for CuesheetCdromBackend {
         Some(&self.tracks)
     }
 
-    fn read_raw_sector(&self, sector: u32) -> Result<RawSector> {
-        let map_entry = self
-            .find_map_entry_for_sector(sector)
-            .ok_or_else(|| anyhow!("Sector {} not found in sector map", sector))?;
-
-        let rel_sector = sector - map_entry.sector;
-
-        let track = get_track_at_sector(&self.tracks, sector)
-            .ok_or_else(|| anyhow!("No track found at sector {}", sector))?;
-        if sector >= self.sessions[track.session as usize - 1].leadout {
-            bail!("Sector {} was past the lead-out", sector);
-        }
-
-        let data = match map_entry.source {
-            SectorSource::Zeros => [0; RAW_SECTOR_LEN],
-            SectorSource::BinaryFile {
-                file_idx,
-                file_offset,
-                format,
-            } => {
-                // It turns out you don't need a &mut File to seek and read!
-                // Just call seek and read on a `&File`. This will clobber the file cursor,
-                // so use with caution.
-                let mut file: &File = &self.binary_files[file_idx];
-                file.seek(SeekFrom::Start(
-                    file_offset + rel_sector as u64 * format.bytes_per_sector(),
-                ))?;
-
-                match format {
-                    BinarySourceFormat::Raw2352 => {
-                        let mut result = [0u8; RAW_SECTOR_LEN];
-                        file.read_exact(&mut result)?;
-                        result
-                    }
-                    BinarySourceFormat::Mode1_2048 => {
-                        // Reconstruct Mode 1 sector from 2048-byte user data.
-                        // Only the most important fields are filled.
-                        let mut result = [0u8; RAW_SECTOR_LEN];
-                        // Sync
-                        result[0..12]
-                            .copy_from_slice(b"\x00\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x00");
-                        // Mode
-                        result[15] = 1;
-                        // User data
-                        file.read_exact(&mut result[16..][..2048])?;
-                        // TODO: fill out more fields?
-                        result
-                    }
-                }
-            }
-            SectorSource::AudioFile {
-                file_idx,
-                timestamp_in_sectors,
-            } => {
-                let mut file = self.audio_files[file_idx].borrow_mut();
-
-                let ts = (timestamp_in_sectors as u64 + rel_sector as u64)
-                    * AUDIO_FRAMES_PER_SECTOR as u64;
-                let samples = file.read_frames(ts, AUDIO_FRAMES_PER_SECTOR)?;
-
-                let mut result = [0u8; RAW_SECTOR_LEN];
-                for (s, out) in samples.into_iter().zip(result.as_chunks_mut::<2>().0) {
-                    out.copy_from_slice(&s.to_le_bytes());
-                }
-
-                result
-            }
-        };
-
-        Ok(RawSector {
-            data,
-            control: track.control,
-        })
+    fn read_cdda_sector(&self, sector: u32) -> Result<RawSector, CdromError> {
+        self.read_raw_sector(sector)
     }
 }

--- a/core/src/mac/scsi/cdrom/backends/iso.rs
+++ b/core/src/mac/scsi/cdrom/backends/iso.rs
@@ -1,4 +1,4 @@
-use anyhow::{Result, bail};
+use anyhow::{Result, anyhow};
 use std::path::Path;
 
 use crate::mac::scsi::{
@@ -36,6 +36,10 @@ impl IsoCdromBackend {
 }
 
 impl CdromBackend for IsoCdromBackend {
+    fn check_media(&mut self) -> Result<(), CdromError> {
+        Ok(())
+    }
+
     fn byte_len(&self) -> usize {
         self.image.byte_len()
     }
@@ -56,9 +60,7 @@ impl CdromBackend for IsoCdromBackend {
         Some(std::slice::from_ref(&self.track))
     }
 
-    fn read_raw_sector(&self, _sector: u32) -> Result<RawSector> {
-        // TODO: reconstruct raw sectors from ISO data
-        // (probably only needed for some disc ripping software to work)
-        bail!("Reading raw sectors is not implemented for ISO files");
+    fn read_cdda_sector(&self, _sector: u32) -> Result<RawSector, CdromError> {
+        Err(anyhow!("Reading CDDA sectors is not implemented for ISO files").into())
     }
 }

--- a/core/src/mac/scsi/cdrom/backends/mod.rs
+++ b/core/src/mac/scsi/cdrom/backends/mod.rs
@@ -1,2 +1,64 @@
+use std::path::{Path, PathBuf};
+
+use anyhow::Result;
+
+use crate::mac::scsi::cdrom::CdromBackend;
+
 pub mod cuesheet;
 pub mod iso;
+#[cfg(windows)]
+pub mod windows_drive;
+
+pub struct PhysicalCdromDrive {
+    pub friendly_name: String,
+    pub path: PathBuf,
+}
+
+/// Query the physical CD-ROM drives available.
+///
+/// Returns an empty Vec if physical CD-ROM drives are supported
+/// but none are available. Returns None if physical CD-ROM drives
+/// are not supported on this platform.
+pub fn query_physical_cdrom_drives() -> Option<Vec<PhysicalCdromDrive>> {
+    #[allow(unused_mut, unused_assignments)]
+    let mut result = None;
+
+    #[cfg(windows)]
+    {
+        result = Some(windows_drive::query_physical_cdrom_drives());
+    }
+
+    result
+}
+
+#[allow(unused_variables)]
+pub fn is_physical_cdrom_drive_path(path: &Path) -> bool {
+    #[allow(unused_mut, unused_assignments)]
+    let mut result = false;
+
+    #[cfg(windows)]
+    {
+        result = windows_drive::is_physical_cdrom_drive_path(path);
+    }
+
+    result
+}
+
+#[allow(unused_variables)]
+pub fn new_physical_cdrom_drive_backend(path: &Path) -> Result<Box<dyn CdromBackend>> {
+    #[allow(unused_mut, unused_assignments)]
+    let mut result = None;
+
+    #[cfg(windows)]
+    {
+        result = Some(Box::new(windows_drive::WindowsDriveCdromBackend::new(
+            path,
+        )?));
+    }
+
+    if result.is_none() {
+        unimplemented!("Physical CD-ROM drives are not supported on this platform");
+    }
+
+    Ok(result.unwrap())
+}

--- a/core/src/mac/scsi/cdrom/backends/windows_drive.rs
+++ b/core/src/mac/scsi/cdrom/backends/windows_drive.rs
@@ -1,0 +1,624 @@
+use std::{
+    ffi::c_void,
+    path::{Path, PathBuf},
+};
+
+use anyhow::{Result, anyhow, bail};
+
+use windows::{
+    Win32::{
+        Devices::Cdrom::*,
+        Foundation::*,
+        Storage::FileSystem::*,
+        System::{IO::*, Ioctl::*, WindowsProgramming::*},
+    },
+    core::HSTRING,
+};
+
+use crate::mac::scsi::{
+    ASC_ILLEGAL_MODE_FOR_THIS_TRACK, ASC_MEDIUM_NOT_PRESENT, CC_KEY_ILLEGAL_REQUEST,
+    CC_KEY_NOT_READY,
+    cdrom::{
+        CdromBackend, CdromError, LBA_START_SECTOR, Msf, QSub, RAW_SECTOR_LEN, RawSector,
+        SessionInfo, TrackInfo, backends::PhysicalCdromDrive,
+    },
+};
+
+fn enum_logical_cdrom_drives() -> Result<Vec<String>> {
+    // Get buffer size
+    let buflen = unsafe { GetLogicalDriveStringsW(None) } as usize;
+
+    // Get logical drives as a sequence of null-terminated names followed by an extra null terminator
+    let mut logical_drives: Vec<u16> = vec![0; buflen];
+    let buflen = unsafe { GetLogicalDriveStringsW(Some(logical_drives.as_mut_slice())) } as usize;
+    if buflen == 0 {
+        bail!("Failed to query logical drives");
+    }
+
+    logical_drives.resize(buflen - 1, 0); // Subtract 1 to omit the last null terminator
+    let logical_drives = logical_drives
+        .split(|c| *c == 0)
+        .filter(|s| unsafe { GetDriveTypeW(&HSTRING::from_wide(s)) } == DRIVE_CDROM)
+        .map(String::from_utf16_lossy)
+        .collect();
+    Ok(logical_drives)
+}
+
+pub fn query_physical_cdrom_drives() -> Vec<PhysicalCdromDrive> {
+    if let Ok(drives) = enum_logical_cdrom_drives() {
+        // TODO: Windows makes it weirdly difficult to get the device name behind
+        // a drive letter, but it might be worth it for the friendly name.
+        drives
+            .iter()
+            .map(|drive| PhysicalCdromDrive {
+                friendly_name: drive.to_string(),
+                path: format!(r"\\.\{}:", drive.chars().nth(0).unwrap()).into(),
+            })
+            .collect()
+    } else {
+        vec![]
+    }
+}
+
+pub fn is_physical_cdrom_drive_path(path: &Path) -> bool {
+    // CD-ROM paths are in the form "\\.\D:" where D is the drive letter.
+    // If a trailing \ is added and passed to GetDriveType, it will report
+    // whether a CD-ROM drive is there.
+    let path = path.join(Path::new("\\"));
+    unsafe { GetDriveTypeW(&HSTRING::from(path.as_path())) == DRIVE_CDROM }
+}
+
+/// Disc information. Changes each time a new disc is inserted.
+struct DiscInfo {
+    capacity: usize,
+    sessions: Vec<SessionInfo>,
+    tracks: Vec<TrackInfo>,
+}
+
+pub struct WindowsDriveCdromBackend {
+    path: PathBuf,
+    handle: HANDLE,
+    curr_media_change_count: Option<u32>,
+    disc_info: Option<DiscInfo>,
+}
+
+// SAFETY: The drive handle should be safe to send between threads.
+unsafe impl Send for WindowsDriveCdromBackend {}
+
+fn get_disk_length(handle: HANDLE) -> Result<i64> {
+    let mut gli = GET_LENGTH_INFORMATION::default();
+
+    unsafe {
+        DeviceIoControl(
+            handle,
+            IOCTL_DISK_GET_LENGTH_INFO,
+            None,
+            0,
+            Some(std::ptr::from_mut(&mut gli).cast::<c_void>()),
+            std::mem::size_of::<GET_LENGTH_INFORMATION>() as u32,
+            None,
+            None,
+        )
+    }?;
+
+    Ok(gli.Length)
+}
+
+fn read_formatted_toc(handle: HANDLE) -> Result<(Vec<SessionInfo>, Vec<TrackInfo>)> {
+    let mut read_toc_cmd = CDROM_READ_TOC_EX::default();
+    let format = CDROM_READ_TOC_EX_FORMAT_TOC as u8;
+    let msf = 1;
+    // Bitfield:
+    // UCHAR Format : 4;
+    // UCHAR Reserved1 : 3;
+    // UCHAR Msf : 1;
+    // Note that in MSVC, bitfields are packed from LSB-to-MSB!
+    read_toc_cmd._bitfield = (msf << 7) | format;
+
+    const HEADER_LEN: usize = std::mem::offset_of!(CDROM_TOC, TrackData);
+
+    let mut out_data = [0u8; std::mem::size_of::<CDROM_TOC>()];
+    let mut bytes_returned = 0u32;
+
+    unsafe {
+        DeviceIoControl(
+            handle,
+            IOCTL_CDROM_READ_TOC_EX,
+            Some(std::ptr::from_ref(&read_toc_cmd).cast::<c_void>()),
+            std::mem::size_of::<CDROM_READ_TOC_EX>() as u32,
+            Some(out_data.as_mut_ptr().cast::<c_void>()),
+            out_data.len() as u32,
+            Some(&mut bytes_returned),
+            None,
+        )
+    }?;
+
+    if (bytes_returned as usize) < HEADER_LEN {
+        bail!("Not enough TOC bytes returned");
+    }
+
+    let toc_len =
+        u16::from_be_bytes(unsafe { out_data.as_ptr().cast::<CDROM_TOC>().read() }.Length) as usize;
+    let toc_data = out_data
+        .get(..bytes_returned as usize)
+        .ok_or_else(|| anyhow!("Invalid number of bytes returned"))?;
+    let toc_data = toc_data
+        .get(..toc_len + 2)
+        .ok_or_else(|| anyhow!("Invalid TOC length field"))?;
+
+    let track_data = &toc_data[HEADER_LEN..];
+    let track_count = track_data.len() / std::mem::size_of::<TRACK_DATA>();
+
+    let track_data = unsafe {
+        std::slice::from_raw_parts(track_data.as_ptr().cast::<TRACK_DATA>(), track_count)
+    };
+
+    let mut leadout = LBA_START_SECTOR;
+    let mut tracks = vec![];
+
+    for data in track_data {
+        let control = data._bitfield & 0xf;
+        let sector = Msf::from_bytes(data.Address[1..=3].try_into().unwrap()).to_sector();
+
+        match data.TrackNumber {
+            1..=99 => {
+                tracks.push(TrackInfo {
+                    tno: data.TrackNumber,
+                    session: 1,
+                    control,
+                    sector,
+                });
+            }
+            0xAA => {
+                leadout = sector;
+                break;
+            }
+            _ => {
+                log::warn!(
+                    "Unhandled TNO 0x{:X} found in formatted TOC",
+                    data.TrackNumber
+                );
+            }
+        }
+    }
+
+    Ok((
+        vec![SessionInfo {
+            number: 1,
+            disc_type: 0x00,
+            leadin: 0,
+            leadout,
+        }],
+        tracks,
+    ))
+}
+
+fn read_full_toc(handle: HANDLE) -> Result<(Vec<SessionInfo>, Vec<TrackInfo>)> {
+    let mut read_toc_cmd = CDROM_READ_TOC_EX::default();
+    let format = CDROM_READ_TOC_EX_FORMAT_FULL_TOC as u8;
+    // MSF is must be 1 when querying full TOC.
+    let msf = 1;
+    // Bitfield:
+    // UCHAR Format : 4;
+    // UCHAR Reserved1 : 3;
+    // UCHAR Msf : 1;
+    // Note that in MSVC, bitfields are packed from LSB-to-MSB!
+    read_toc_cmd._bitfield = (msf << 7) | format;
+
+    // Note: struct CDROM_TOC_FULL_TOC_DATA contains an array of 1 descriptor,
+    // but there can actually be many descriptors following the header.
+    const HEADER_LEN: usize = std::mem::offset_of!(CDROM_TOC_FULL_TOC_DATA, Descriptors);
+    // Note: Passing any value greater than MAX_OUT_LEN for the output size causes
+    // DeviceIoControl to throw an invalid parameter error.
+    const MAX_OUT_LEN: usize =
+        HEADER_LEN + 100 * std::mem::size_of::<CDROM_TOC_FULL_TOC_DATA_BLOCK>();
+
+    let mut out_data = [0u8; MAX_OUT_LEN];
+    let mut bytes_returned: u32 = 0;
+
+    unsafe {
+        DeviceIoControl(
+            handle,
+            IOCTL_CDROM_READ_TOC_EX,
+            Some(std::ptr::from_ref(&read_toc_cmd).cast::<c_void>()),
+            std::mem::size_of::<CDROM_READ_TOC_EX>() as u32,
+            Some(out_data.as_mut_ptr().cast::<c_void>()),
+            out_data.len() as u32,
+            Some(&mut bytes_returned),
+            None,
+        )
+    }?;
+
+    if (bytes_returned as usize) < HEADER_LEN {
+        bail!("Not enough TOC bytes returned");
+    }
+
+    let toc_len = u16::from_be_bytes(
+        unsafe { out_data.as_ptr().cast::<CDROM_TOC_FULL_TOC_DATA>().read() }.Length,
+    ) as usize;
+    let toc_data = out_data
+        .get(..bytes_returned as usize)
+        .ok_or_else(|| anyhow!("Invalid number of bytes returned"))?;
+    let toc_data = toc_data
+        .get(0..toc_len + 2)
+        .ok_or_else(|| anyhow!("Invalid Full TOC length field"))?;
+
+    let descriptors = &toc_data[HEADER_LEN..];
+    let descriptor_count = descriptors.len() / std::mem::size_of::<CDROM_TOC_FULL_TOC_DATA_BLOCK>();
+
+    let descriptors = unsafe {
+        std::slice::from_raw_parts(
+            descriptors.as_ptr().cast::<CDROM_TOC_FULL_TOC_DATA_BLOCK>(),
+            descriptor_count,
+        )
+    };
+
+    let mut sessions = vec![];
+    let mut tracks = vec![];
+    let mut next_leadin = 0;
+
+    for (i, desc) in descriptors.iter().enumerate() {
+        let adr = desc._bitfield >> 4;
+        let control = desc._bitfield & 0xf;
+        log::debug!(
+            "#{}: session {} adr {} control {} tno {} point {} msf_extra {} msf {}",
+            i,
+            desc.SessionNumber,
+            adr,
+            control,
+            desc.Reserved1, // Actually the TNO field?
+            desc.Point,
+            Msf::from_bytes(desc.MsfExtra),
+            Msf::from_bytes(desc.Msf),
+        );
+
+        if desc.SessionNumber as usize > sessions.len() {
+            let leadout = sessions
+                .last()
+                .map(|s: &SessionInfo| s.leadout)
+                .unwrap_or(LBA_START_SECTOR);
+            while sessions.len() < desc.SessionNumber as usize {
+                sessions.push(SessionInfo {
+                    number: (sessions.len() + 1).try_into().unwrap(),
+                    disc_type: 0x00,
+                    leadin: next_leadin,
+                    leadout,
+                });
+                next_leadin = leadout;
+            }
+        }
+
+        // SessionNumber starts at 1. Subtract 1 to get the index into the session array.
+        let session = desc
+            .SessionNumber
+            .checked_sub(1)
+            .and_then(|n| sessions.get_mut(n as usize))
+            .ok_or_else(|| anyhow!("Invalid session number"))?;
+
+        match desc.Point {
+            0xA0 => {
+                // First Track Number/Disc Type
+                session.disc_type = desc.Msf[1];
+            }
+            0xA1 => (), // Last Track Number (ignored)
+            0xA2 => {
+                // Start position of Lead-out
+                session.leadout = Msf::from_bytes(desc.Msf).to_sector();
+                if next_leadin < session.leadout {
+                    next_leadin = session.leadout;
+                }
+            }
+            0xB0 => {
+                // Start time of next possible program
+                next_leadin = Msf::from_bytes(desc.MsfExtra).to_sector();
+            }
+            0xC0 => (), // Start time of the first Lead-in Area of the disc (ignored)
+            1..=99 => {
+                // Track
+                tracks.push(TrackInfo {
+                    tno: desc.Point,
+                    session: desc.SessionNumber,
+                    control,
+                    sector: Msf::from_bytes(desc.Msf).to_sector(),
+                });
+            }
+            _ => log::warn!("TOC contains unhandled POINT value 0x{:X}", desc.Point),
+        }
+    }
+
+    Ok((sessions, tracks))
+}
+
+fn read_ioctl_cdrom_raw_read(
+    drive: HANDLE,
+    lba: u32,
+) -> Result<[u8; CD_RAW_SECTOR_WITH_SUBCODE_SIZE as usize]> {
+    let read_cmd = RAW_READ_INFO {
+        DiskOffset: lba as i64 * 2048,
+        SectorCount: 1,
+        TrackMode: RawWithSubCode,
+    };
+
+    let mut out_data = [0u8; CD_RAW_SECTOR_WITH_SUBCODE_SIZE as usize];
+    let mut bytes_returned: u32 = 0;
+
+    unsafe {
+        DeviceIoControl(
+            drive,
+            IOCTL_CDROM_RAW_READ,
+            Some(std::ptr::from_ref(&read_cmd).cast::<c_void>()),
+            std::mem::size_of::<RAW_READ_INFO>() as u32,
+            Some(out_data.as_mut_ptr().cast::<c_void>()),
+            out_data.len() as u32,
+            Some(&mut bytes_returned),
+            None,
+        )
+    }?;
+
+    if bytes_returned != CD_RAW_SECTOR_WITH_SUBCODE_SIZE {
+        log::warn!("Raw read only returned {} bytes", bytes_returned);
+    }
+
+    Ok(out_data)
+}
+
+// Decode one of the P-W channels in the subcode data returned by IOCTL_CDROM_RAW_READ
+fn decode_subcode(subcode: [u8; 96], bit: u8) -> [u8; 12] {
+    let mask = 0x80 >> bit;
+    let mut result = [0; 12];
+
+    for i in 0..12 {
+        let mut b = 0u8;
+        for j in 0..8 {
+            if subcode[8 * i + j] & mask != 0 {
+                b |= 0x80 >> j;
+            }
+        }
+        result[i] = b;
+    }
+
+    result
+}
+
+fn get_media_change_count(drive: HANDLE) -> Result<Option<u32>> {
+    let mut media_change_count = 0u32;
+    let mut bytes_returned: u32 = 0;
+
+    let status = unsafe {
+        DeviceIoControl(
+            drive,
+            IOCTL_STORAGE_CHECK_VERIFY,
+            None,
+            0,
+            Some(std::ptr::from_mut(&mut media_change_count).cast::<c_void>()),
+            std::mem::size_of::<u32>().try_into().unwrap(),
+            Some(&mut bytes_returned),
+            None,
+        )
+    };
+
+    match status {
+        Ok(()) => (),
+        Err(e) => {
+            if e.code() == ERROR_NOT_READY.into() {
+                return Ok(None);
+            }
+
+            return Err(e.into());
+        }
+    }
+
+    if bytes_returned != std::mem::size_of::<u32>() as u32 {
+        return Ok(None);
+    }
+
+    Ok(Some(media_change_count))
+}
+
+impl WindowsDriveCdromBackend {
+    pub fn new(path: &Path) -> Result<Self> {
+        let handle = unsafe {
+            CreateFileW(
+                &HSTRING::from(path),
+                GENERIC_READ.0,
+                FILE_SHARE_READ,
+                None,
+                OPEN_EXISTING,
+                FILE_ATTRIBUTE_NORMAL,
+                None,
+            )
+        }?;
+
+        // Allow read commands to be sent directly to the driver without filtering.
+        // Without this, Microsoft Virtual DVD-ROM will read all 0's on some sectors.
+        let _ = unsafe {
+            DeviceIoControl(
+                handle,
+                FSCTL_ALLOW_EXTENDED_DASD_IO,
+                None,
+                0,
+                None,
+                0,
+                None,
+                None,
+            )
+        };
+
+        let mut self_ = Self {
+            path: path.into(),
+            handle,
+            curr_media_change_count: get_media_change_count(handle)?,
+            disc_info: None,
+        };
+
+        self_.reload_media()?;
+
+        Ok(self_)
+    }
+}
+
+impl WindowsDriveCdromBackend {
+    fn reload_media(&mut self) -> Result<()> {
+        log::debug!("Loading new CD media...");
+
+        drop(self.disc_info.take());
+
+        let capacity: usize = get_disk_length(self.handle)?.try_into()?;
+        log::debug!("detected capacity: 0x{:X}", capacity);
+
+        let (sessions, tracks) = read_full_toc(self.handle).or_else(|e| {
+            // Microsoft Virtual DVD-ROM supports Formatted TOC but not Full TOC.
+            log::warn!(
+                "Failed to read Full TOC; falling back to Formatted TOC. Error: {}",
+                e
+            );
+            read_formatted_toc(self.handle)
+        })?;
+
+        log::debug!("sessions: {:#?}", sessions);
+        log::debug!("tracks: {:#?}", tracks);
+
+        // XXX: Workaround an issue in Windows:
+        // If ReadFile is performed on a drive handle before IOCTL_CDROM_RAW_READ,
+        // IOCTL_CDROM_RAW_READ will stop working with "The parameter is incorrect."
+        // This seems to fix it.
+        let _ = read_ioctl_cdrom_raw_read(self.handle, 0);
+
+        self.disc_info = Some(DiscInfo {
+            capacity,
+            sessions,
+            tracks,
+        });
+
+        Ok(())
+    }
+}
+
+impl CdromBackend for WindowsDriveCdromBackend {
+    fn check_media(&mut self) -> Result<(), CdromError> {
+        let media_change_count = match get_media_change_count(self.handle) {
+            Ok(count) => count,
+            Err(e) => {
+                if let Some(we) = e.downcast_ref::<windows_result::Error>()
+                    && we.code() == ERROR_DEV_NOT_EXIST.into()
+                {
+                    return Err(CdromError::BackendDead);
+                }
+
+                return Err(CdromError::Other(e));
+            }
+        };
+
+        if media_change_count != self.curr_media_change_count {
+            drop(self.disc_info.take());
+
+            if media_change_count.is_some() {
+                log::warn!("Media change detected, reloading...");
+                self.reload_media()?;
+            } else {
+                log::warn!("Media change detected, unloading...");
+            }
+
+            self.curr_media_change_count = media_change_count;
+        }
+
+        if media_change_count.is_some() {
+            Ok(())
+        } else {
+            Err(CdromError::CheckCondition(
+                CC_KEY_NOT_READY,
+                ASC_MEDIUM_NOT_PRESENT,
+            ))
+        }
+    }
+
+    fn byte_len(&self) -> usize {
+        self.disc_info
+            .as_ref()
+            .map(|info| info.capacity)
+            .unwrap_or(0)
+    }
+
+    fn read_bytes(&self, offset: usize, length: usize) -> Result<Vec<u8>, CdromError> {
+        // log::debug!("Reading 0x{:X} bytes from offset 0x{:X}", length, offset);
+
+        // If move method is FILE_BEGIN, offset is treated as an unsigned value.
+        unsafe { SetFilePointerEx(self.handle, offset as i64, None, FILE_BEGIN) }
+            .map_err(|e| anyhow!(e))?;
+
+        let mut result = vec![0; length];
+        unsafe { ReadFile(self.handle, Some(result.as_mut_slice()), None, None) }.map_err(|e| {
+            if e.code() == ERROR_INVALID_FUNCTION.into() {
+                // ReadFile returns ERROR_INVALID_FUNCTION if you try to read an audio sector.
+                log::warn!("Read failed with ERROR_INVALID_FUNCTION");
+                CdromError::CheckCondition(CC_KEY_ILLEGAL_REQUEST, ASC_ILLEGAL_MODE_FOR_THIS_TRACK)
+            } else if e.code() == ERROR_NOT_READY.into() {
+                // ReadFile returns ERROR_NOT_READY if you eject the disc.
+                log::warn!("Read failed with ERROR_NOT_READY");
+                CdromError::CheckCondition(CC_KEY_NOT_READY, ASC_MEDIUM_NOT_PRESENT)
+            } else if e.code() == ERROR_FILE_INVALID.into() {
+                // ReadFile returns ERROR_FILE_INVALID if the CD-ROM drive was unplugged.
+                log::warn!("Read failed with ERROR_FILE_INVALID");
+                CdromError::BackendDead
+            } else {
+                CdromError::Other(e.into())
+            }
+        })?;
+
+        Ok(result)
+    }
+
+    fn image_path(&self) -> Option<&Path> {
+        Some(&self.path)
+    }
+
+    fn sessions(&self) -> Option<&[SessionInfo]> {
+        Some(&self.disc_info.as_ref()?.sessions)
+    }
+
+    fn tracks(&self) -> Option<&[TrackInfo]> {
+        Some(&self.disc_info.as_ref()?.tracks)
+    }
+
+    fn read_cdda_sector(&self, sector: u32) -> Result<RawSector, CdromError> {
+        if self.disc_info.is_none() {
+            return Err(CdromError::CheckCondition(
+                CC_KEY_NOT_READY,
+                ASC_MEDIUM_NOT_PRESENT,
+            ));
+        };
+
+        // log::debug!("Reading raw sector {}", sector);
+        let lba = sector
+            .checked_sub(LBA_START_SECTOR)
+            .ok_or_else(|| anyhow!("Tried to read from inaccessible sector {}", sector))?;
+
+        let status = read_ioctl_cdrom_raw_read(self.handle, lba);
+        match status {
+            Ok(data) => Ok(RawSector {
+                data: data[..RAW_SECTOR_LEN].try_into().unwrap(),
+                qsub: QSub(decode_subcode(
+                    data[RAW_SECTOR_LEN..].try_into().unwrap(),
+                    1,
+                )),
+            }),
+            Err(e) => {
+                if let Some(e) = e.downcast_ref::<windows_result::Error>() {
+                    if e.code() == ERROR_NOT_READY.into() || e.code() == ERROR_MEDIA_CHANGED.into()
+                    {
+                        return Err(CdromError::CheckCondition(
+                            CC_KEY_NOT_READY,
+                            ASC_MEDIUM_NOT_PRESENT,
+                        ));
+                    } else if e.code() == ERROR_DEV_NOT_EXIST.into()
+                        || e.code() == ERROR_NO_SUCH_DEVICE.into()
+                    {
+                        return Err(CdromError::BackendDead);
+                    }
+                }
+
+                Err(CdromError::Other(e))
+            }
+        }
+    }
+}

--- a/core/src/mac/scsi/cdrom/mod.rs
+++ b/core/src/mac/scsi/cdrom/mod.rs
@@ -1,37 +1,37 @@
 //! SCSI CD-ROM drive (block device)
 
-mod backends;
+pub mod backends;
 
 use anyhow::{Result, anyhow, bail};
 use serde::{Deserialize, Serialize};
 use std::path::Path;
 
-use crate::debuggable::Debuggable;
-use crate::emulator::EmuContext;
-use crate::emulator::comm::EmulatorSpeed;
-use crate::mac::macii::bus::CLOCK_SPEED;
-use crate::mac::scsi::cdrom::backends::cuesheet::CuesheetCdromBackend;
-use crate::mac::scsi::cdrom::backends::iso::IsoCdromBackend;
-use crate::mac::scsi::target::ScsiTargetCommon;
-use crate::mac::scsi::{
-    ASC_ILLEGAL_MODE_FOR_THIS_TRACK, ASC_INVALID_COMMAND, ASC_LOGICAL_BLOCK_ADDRESS_OUT_OF_RANGE,
-    ASC_UNRECOVERED_READ_ERROR, CC_KEY_NOT_READY,
+use crate::{
+    debuggable::Debuggable,
+    emulator::{EmuContext, comm::EmulatorSpeed},
+    mac::{
+        macii::bus::CLOCK_SPEED,
+        scsi::{
+            ASC_ILLEGAL_MODE_FOR_THIS_TRACK, ASC_INVALID_COMMAND,
+            ASC_LOGICAL_BLOCK_ADDRESS_OUT_OF_RANGE, ASC_UNRECOVERED_READ_ERROR, CC_KEY_NOT_READY,
+            cdrom::backends::{
+                cuesheet::CuesheetCdromBackend, is_physical_cdrom_drive_path, iso::IsoCdromBackend,
+                new_physical_cdrom_drive_backend,
+            },
+            target::ScsiTargetCommon,
+        },
+    },
+    renderer::{AUDIO_BUFFER_SAMPLES, AudioProvider, AudioSink},
+    tickable::Ticks,
+    types::LatchingEvent,
 };
-use crate::renderer::{AUDIO_BUFFER_SAMPLES, AudioProvider, AudioSink};
-use crate::tickable::Ticks;
-use crate::types::LatchingEvent;
 
-use super::ASC_INVALID_FIELD_IN_CDB;
-use super::ASC_MEDIUM_NOT_PRESENT;
-use super::CC_KEY_ILLEGAL_REQUEST;
-use super::CC_KEY_MEDIUM_ERROR;
-use super::STATUS_CHECK_CONDITION;
-use super::STATUS_GOOD;
-use super::ScsiCmdResult;
-use super::disk_image::{DiskImage, FileDiskImage};
-use super::target::ScsiTarget;
-use super::target::ScsiTargetEvent;
-use super::target::ScsiTargetType;
+use super::{
+    ASC_INVALID_FIELD_IN_CDB, ASC_MEDIUM_NOT_PRESENT, CC_KEY_ILLEGAL_REQUEST, CC_KEY_MEDIUM_ERROR,
+    STATUS_CHECK_CONDITION, STATUS_GOOD, ScsiCmdResult,
+    disk_image::{DiskImage, FileDiskImage},
+    target::{ScsiTarget, ScsiTargetEvent, ScsiTargetType},
+};
 
 // CD-ROM protocol Documentation:
 //
@@ -73,6 +73,10 @@ const AUDIO_FRAMES_PER_SECTOR: usize =
 
 fn bin_to_bcd(bin: u8) -> u8 {
     ((bin / 10) << 4) | (bin % 10)
+}
+
+fn bcd_to_bin(bcd: u8) -> u8 {
+    (bcd >> 4) * 10 + (bcd & 0xf)
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
@@ -119,7 +123,7 @@ impl std::fmt::Display for Msf {
     }
 }
 
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug)]
 pub struct TrackInfo {
     /// The track number. Note that tracks don't necessarily start at number 1.
     tno: u8,
@@ -146,6 +150,9 @@ pub struct SessionInfo {
 pub enum CdromError {
     /// SCSI read error with CC, ASC/ASCQ
     CheckCondition(u8, u16),
+    /// The backend is dead (e.g. an external CD-ROM drive was unplugged) and is
+    /// no longer usable.
+    BackendDead,
     /// Any other type of error
     Other(anyhow::Error),
 }
@@ -156,17 +163,127 @@ impl From<anyhow::Error> for CdromError {
     }
 }
 
+/// 12 bytes of Q subchannel data.
+///
+/// The first byte always contains Control/ADR. If ADR is 1, the remainder of QSub
+/// contains Track and Index, relative time and absolute time. Note that times are
+/// in BCD format.
+///
+/// See [MMC4] Table 354: Formatted Q-Subchannel Data
+/// and [MMC4] 4.2.4.5.1: Types of Q.
+#[derive(Serialize, Deserialize)]
+pub struct QSub([u8; 12]);
+
+impl QSub {
+    /// Create a Mode-1 Q field with the given information
+    fn new_mode1(control: u8, tno: u8, index: u8, abs_sector: u32, track_start: u32) -> Self {
+        let mut result = [0; 12];
+
+        result[0] = (control << 4) | 1; // Control/ADR; this is reversed from other ADR/Control fields in the standard
+        result[1] = bin_to_bcd(tno);
+        result[2] = bin_to_bcd(index);
+
+        // [MMC4] 4.2.4.5.2:
+        // Is the relative time within the track encoded as 6 BCD digits. This is
+        // 00:00:00 at track start and advances through the track. During the
+        // pre-gap the time decreases.
+        // (in other words, if abs_sector is before track_start, the relative time counts down)
+        let rel_time = abs_sector as i64 - track_start as i64;
+        let rel_time_msf = if rel_time < 0 {
+            Msf::from_sector(u32::try_from(-rel_time).unwrap()).unwrap()
+        } else {
+            Msf::from_sector(u32::try_from(rel_time).unwrap()).unwrap()
+        };
+        result[3..=5].copy_from_slice(&rel_time_msf.to_bcd_bytes()); // MIN, SEC, FRAME
+
+        // result[6] is ZERO
+
+        result[7..=9].copy_from_slice(&Msf::from_sector(abs_sector).unwrap().to_bcd_bytes()); // AMIN, ASEC, AFRAME
+
+        // result[10..=11] is an optional CRC; we leave it out
+
+        Self(result)
+    }
+
+    /// Get ADR field
+    fn adr(&self) -> u8 {
+        self.0[0] & 0xf
+    }
+
+    /// Get CONTROL field (indicates audio/data; see [MMC4] Table 12: Q Sub-channel record format)
+    fn control(&self) -> u8 {
+        self.0[0] >> 4
+    }
+
+    fn is_audio(&self) -> bool {
+        self.control() & 0b0100 == 0
+    }
+
+    fn is_data(&self) -> bool {
+        !self.is_audio()
+    }
+
+    fn track(&self) -> u8 {
+        assert_eq!(self.adr(), 1);
+        bcd_to_bin(self.0[1])
+    }
+
+    fn index(&self) -> u8 {
+        assert_eq!(self.adr(), 1);
+        bcd_to_bin(self.0[2])
+    }
+
+    fn rel_time_in_sectors(&self) -> i32 {
+        assert_eq!(self.adr(), 1);
+        let rel_time_bytes: [u8; 3] = self.0[3..=5].try_into().unwrap();
+        let rel_time_sectors = Msf::from_bytes(rel_time_bytes.map(bcd_to_bin)).to_sector();
+        if self.index() == 0 {
+            // Rel time is negative and counts down to 0
+            -i32::try_from(rel_time_sectors).unwrap()
+        } else {
+            // Rel time is positive
+            i32::try_from(rel_time_sectors).unwrap()
+        }
+    }
+
+    fn abs_sector(&self) -> u32 {
+        assert_eq!(self.adr(), 1);
+        let abs_time_bytes: [u8; 3] = self.0[7..=9].try_into().unwrap();
+        Msf::from_bytes(abs_time_bytes.map(bcd_to_bin)).to_sector()
+    }
+}
+
+impl Default for QSub {
+    fn default() -> Self {
+        Self::new_mode1(0, 1, 1, LBA_START_SECTOR, LBA_START_SECTOR)
+    }
+}
+
 pub struct RawSector {
+    /// 2352 bytes of data (equivalent to 1/75th seconds of audio)
     data: [u8; RAW_SECTOR_LEN],
-    /// CONTROL field of sub-channel data. Indicates audio or data track.
-    control: u8,
-    // TODO: add fields for other sub-channel data (position, track/index number, etc.)
+    /// Q subchannel data. Contains various metadata about the sector.
+    qsub: QSub,
 }
 
 pub trait CdromBackend: Send {
+    /// Check whether a disc is still in the drive and reload TOC's if necessary. Returns
+    /// Ok(()) if the drive is plugged in and a disc is mounted, or a CdromError if an error
+    /// occurred.
+    fn check_media(&mut self) -> Result<(), CdromError>;
+
+    /// Get the byte capacity of the CD, where each sector starting at #150 contains 2048
+    /// bytes of user data.
+    ///
+    /// Every sector up to the lead-out is counted toward the capacity; however, only Data
+    /// sectors in Mode 1 or Mode 2 Form 1 can be accessed via READ commands.
     fn byte_len(&self) -> usize;
 
-    /// The SCSI CD-ROM protocol allows reading blocks with standard READ commands.
+    /// Read user data from the CD.
+    ///
+    /// The SCSI CD-ROM protocol presents the CD as block device that can be read via standard
+    /// READ commands. Blocks begin at sector 150. Each sector contains 2048 bytes of user
+    /// data.
     ///
     /// Each sector accessed by this method is expected to be a Mode 1 or Mode 2 Form 1
     /// sector containing 2048 bytes of user data. If the wrong type of sector is accessed,
@@ -178,8 +295,8 @@ pub trait CdromBackend: Send {
     fn sessions(&self) -> Option<&[SessionInfo]>;
     fn tracks(&self) -> Option<&[TrackInfo]>;
 
-    /// Read a raw 2352-byte sector. Currently used only for CD audio. Other data is read via read_bytes.
-    fn read_raw_sector(&self, sector: u32) -> Result<RawSector>;
+    /// Read a raw CD Digital Audio sector. Other types of sectors are read via `read_bytes`.
+    fn read_cdda_sector(&self, sector: u32) -> Result<RawSector, CdromError>;
 }
 
 #[derive(PartialEq, Eq, Serialize, Deserialize)]
@@ -222,6 +339,9 @@ pub(super) struct ScsiTargetCdrom {
     /// Quadraphonic CD's are extremely rare but apparently existed.
     audio_ports: [AudioPort; 4],
 
+    /// Last Q-subchannel data with ADR=1; used to report current playback position
+    curr_mode1_qsub: QSub,
+
     /// Audio clock (counts bus ticks)
     audio_clock: Ticks,
 
@@ -261,6 +381,7 @@ impl ScsiTargetCdrom {
                     channel: 0b1000,
                 },
             ],
+            curr_mode1_qsub: Default::default(),
             audio_sink: None,
         };
         if let Some(audio_provider) = audio_provider {
@@ -292,11 +413,12 @@ impl ScsiTargetCdrom {
         track_or_session: u8, // Interpretation depends on format
         alloc_len: usize,
     ) -> Result<ScsiCmdResult> {
-        let Some(backend) = &self.backend else {
-            // No CD inserted
-            self.common.set_cc(CC_KEY_NOT_READY, ASC_MEDIUM_NOT_PRESENT);
-            return Ok(ScsiCmdResult::Status(STATUS_CHECK_CONDITION));
-        };
+        let check_result = self.unit_ready();
+        if !matches!(check_result, Ok(ScsiCmdResult::Status(STATUS_GOOD))) {
+            return check_result;
+        }
+
+        let backend = self.backend.as_ref().unwrap();
 
         let Some(tracks) = backend.tracks() else {
             // Media does not support tracks
@@ -343,7 +465,7 @@ impl ScsiTargetCdrom {
                     // Absolute CD-ROM Address
                 }
 
-                // Emit leadout track descriptor
+                // Emit leadout descriptor
                 result.push(0); // Reserved
                 result.push((1 << 4) | tracks.last().unwrap().control); // ADR/Control
                 result.push(TRACK_LEADOUT); // Track Number
@@ -538,6 +660,45 @@ impl ScsiTargetCdrom {
         self.audio_pos = LBA_START_SECTOR;
     }
 
+    /// Check audio position and make sure it is in a playable sector.
+    ///
+    /// If audio position is past the stop point, stop playback.
+    /// If audio position is within a session gap, skip to the next session.
+    fn resolve_audio_pos(&mut self) {
+        let Some(backend) = &self.backend else {
+            self.audio_state = AudioState::Stopped;
+            return;
+        };
+
+        let Some(sessions) = backend.sessions() else {
+            self.audio_state = AudioState::Stopped;
+            return;
+        };
+
+        let curr_session = sessions
+            .iter()
+            .rev()
+            .find(|s| s.leadin <= self.audio_pos)
+            .unwrap();
+        if self.audio_pos < curr_session.leadin + LBA_START_SECTOR {
+            // Audio position is in the leadin; skip to the program area
+            self.audio_pos = curr_session.leadin + LBA_START_SECTOR;
+        } else if self.audio_pos >= curr_session.leadout {
+            // Audio position is past the leadout; skip to the next session
+            let next_session = sessions.get((curr_session.number as usize + 1).saturating_sub(1));
+            if let Some(next_session) = next_session {
+                self.audio_pos = next_session.leadin + LBA_START_SECTOR;
+            } else {
+                // There is no next session; stop the audio
+                self.audio_pos = self.audio_stop;
+            }
+        }
+
+        if self.audio_pos >= self.audio_stop {
+            self.audio_state = AudioState::Stopped;
+        }
+    }
+
     /// Read a frame of CD audio and send it to the audio sink.
     fn pump_audio(&mut self) -> Result<()> {
         let audio_sink = self.audio_sink.as_ref().unwrap();
@@ -546,21 +707,20 @@ impl ScsiTargetCdrom {
             return Ok(());
         }
 
-        let Some(backend) = &self.backend else {
-            return Ok(());
-        };
-
         // Keep audio clock as 0 if real audio is active
         self.audio_clock = 0;
+
+        self.resolve_audio_pos();
 
         if self.audio_state != AudioState::Playing {
             return Ok(());
         }
 
-        if self.audio_pos >= self.audio_stop {
-            self.audio_state = AudioState::Stopped;
+        let audio_sink = self.audio_sink.as_ref().unwrap();
+
+        let Some(backend) = &self.backend else {
             return Ok(());
-        }
+        };
 
         let make_out_sample = |port: &AudioPort, channel_samples: &[i16; 4]| -> f32 {
             let sample = match port.channel {
@@ -573,9 +733,17 @@ impl ScsiTargetCdrom {
             sample as f32 / 32768.0 * port.volume as f32 / 255.0
         };
 
-        let samples = backend.read_raw_sector(self.audio_pos);
+        let samples = backend.read_cdda_sector(self.audio_pos);
         match samples {
-            Ok(samples) if samples.control == AUDIO_TRACK => {
+            Ok(samples) => {
+                // XXX: Do not require QSub CONTROL field to say audio here.
+                // For some reason, some discs report CONTROL=4 (Data track) within
+                // the sectors of audio tracks.
+                // Example: Sector 51848 (11:31:23) of Weird Al - Bad Hair Day.
+                if samples.qsub.adr() == 1 {
+                    self.curr_mode1_qsub = samples.qsub;
+                }
+
                 let mut samples = samples
                     .data
                     .chunks_exact(2)
@@ -594,11 +762,15 @@ impl ScsiTargetCdrom {
 
                 audio_sink.send(Box::new(out_samples))?;
             }
-            Ok(_) => {
-                log::warn!("Tried to play from non-audio track");
+            Err(CdromError::CheckCondition(_, _)) => {
+                // CD-ROM error while playing; disable playback
                 self.audio_state = AudioState::Stopped;
             }
-            Err(e) => {
+            Err(CdromError::BackendDead) => {
+                log::warn!("The CD-ROM drive became unusable");
+                self.eject_media();
+            }
+            Err(CdromError::Other(e)) => {
                 log::warn!(
                     "Failed to read raw samples from sector {}: {}",
                     self.audio_pos,
@@ -652,9 +824,11 @@ impl ScsiTargetCdrom {
         Ok(())
     }
 
-    fn get_track_at_sector(&self, sector: u32) -> Option<&TrackInfo> {
-        let tracks = self.backend.as_ref()?.tracks()?;
-        get_track_at_sector(tracks, sector)
+    fn load_physical_drive(&mut self, path: &Path) -> Result<()> {
+        self.backend = Some(new_physical_cdrom_drive_backend(path)?);
+        self.common.set_cc(0, 0);
+        self.event_eject.get_clear();
+        Ok(())
     }
 }
 
@@ -670,7 +844,9 @@ impl ScsiTarget for ScsiTargetCdrom {
     /// the emulator for fast access and automatic writes back to disk,
     /// at the discretion of the operating system.
     fn load_media(&mut self, path: &Path) -> Result<()> {
-        if path
+        if is_physical_cdrom_drive_path(path) {
+            self.load_physical_drive(path)
+        } else if path
             .extension()
             .map(|ext| ext.eq_ignore_ascii_case("cue"))
             .unwrap_or(false)
@@ -702,13 +878,25 @@ impl ScsiTarget for ScsiTargetCdrom {
     }
 
     fn unit_ready(&mut self) -> Result<ScsiCmdResult> {
-        if self.backend.is_some() {
-            // CD inserted, ready
-            Ok(ScsiCmdResult::Status(STATUS_GOOD))
-        } else {
+        let Some(backend) = &mut self.backend else {
             // No CD inserted
             self.common.set_cc(CC_KEY_NOT_READY, ASC_MEDIUM_NOT_PRESENT);
-            Ok(ScsiCmdResult::Status(STATUS_CHECK_CONDITION))
+            return Ok(ScsiCmdResult::Status(STATUS_CHECK_CONDITION));
+        };
+
+        match backend.check_media() {
+            Ok(()) => Ok(ScsiCmdResult::Status(STATUS_GOOD)),
+            Err(CdromError::CheckCondition(key, asc)) => {
+                self.common.set_cc(key, asc);
+                Ok(ScsiCmdResult::Status(STATUS_CHECK_CONDITION))
+            }
+            Err(CdromError::BackendDead) => {
+                log::error!("The CD-ROM drive became unusable");
+                self.eject_media();
+                self.common.set_cc(CC_KEY_NOT_READY, ASC_MEDIUM_NOT_PRESENT);
+                Ok(ScsiCmdResult::Status(STATUS_CHECK_CONDITION))
+            }
+            Err(CdromError::Other(e)) => Err(e),
         }
     }
 
@@ -876,7 +1064,19 @@ impl ScsiTarget for ScsiTargetCdrom {
                 self.common.set_cc(cc, asc);
                 Ok(ScsiCmdResult::Status(STATUS_CHECK_CONDITION))
             }
+            Err(CdromError::BackendDead) => {
+                log::error!("The CD-ROM drive became unusable");
+                self.eject_media();
+                self.common.set_cc(CC_KEY_NOT_READY, ASC_MEDIUM_NOT_PRESENT);
+                Ok(ScsiCmdResult::Status(STATUS_CHECK_CONDITION))
+            }
             Err(CdromError::Other(e)) => {
+                log::error!(
+                    "Error reading CD-ROM block at 0x{:X}, length 0x{:X}: {}",
+                    start_offset,
+                    image_end_offset - start_offset,
+                    e
+                );
                 self.common
                     .set_cc(CC_KEY_MEDIUM_ERROR, ASC_UNRECOVERED_READ_ERROR);
                 Err(e)
@@ -972,36 +1172,25 @@ impl ScsiTarget for ScsiTargetCdrom {
                 match format {
                     0x01 => {
                         // CD-ROM Current Position
-                        // Find current track at playback position
-                        let Some(track) = self.get_track_at_sector(self.audio_pos) else {
-                            // No tracks available
-                            // FIXME: is this correct?
-                            self.common.set_cc(CC_KEY_NOT_READY, ASC_MEDIUM_NOT_PRESENT);
-                            return Ok(ScsiCmdResult::Status(STATUS_CHECK_CONDITION));
-                        };
-
-                        // log::debug!(
-                        //     "audio pos is at sector {} (in track #{} at sector {})",
-                        //     self.audio_pos,
-                        //     track.tno,
-                        //     track.sector
-                        // );
-
-                        // FIXME: This code tries to guess the subchannel info based on the TOC.
-                        // Instead, the backend should return subchannel info along with
-                        // read_raw_sector.
-
-                        // [PIONEER] Table 2-27F: CD-ROM Current Position Data Block
                         result.push(0x01); // Sub Channel Data Format code
-                        result.push((1 << 4) | track.control); // ADR/Control
-                        result.push(track.tno); // Track Number
-                        result.push(1); // Index Number (TODO: Find correct index number)
+                        result.push((1 << 4) | self.curr_mode1_qsub.control()); // ADR/Control
+                        result.push(self.curr_mode1_qsub.track()); // Track Number
+                        result.push(self.curr_mode1_qsub.index()); // Index Number
                         result.extend_from_slice(
                             &self.msf_to_address_field(Msf::from_sector(self.audio_pos)?, msf != 0),
                         );
+
+                        // [MMC4] 6.29.3.3:
+                        // When the type of information encoded in the Q Sub-channel of the current sector is
+                        // the media catalog number or ISRC, the track, index, and address fields should be extrapolated
+                        // from the previous sector.
+                        // (Not all audio sectors contain position info in their Q-subchannel. If the current
+                        // audio sector doesn't contain position info, extrapolate from the last reported position info.)
                         // Track relative position can be negative if the audio position is in a track pregap.
-                        let track_relative = self.audio_pos as i32 - track.sector as i32;
-                        if let Ok(track_relative) = TryInto::<u32>::try_into(track_relative) {
+                        let pos_delta =
+                            self.audio_pos as i32 - self.curr_mode1_qsub.abs_sector() as i32;
+                        let rel_time = self.curr_mode1_qsub.rel_time_in_sectors() + pos_delta;
+                        if let Ok(track_relative) = TryInto::<u32>::try_into(rel_time) {
                             // Track relative position is positive.
                             result.extend_from_slice(
                                 &self.msf_to_address_field(
@@ -1015,14 +1204,17 @@ impl ScsiTarget for ScsiTargetCdrom {
                             // If the
                             // TIME bit is set to one, this field is the relative TIME address from the Q Sub-channel formatted
                             // according to Table 29.
-                            // FIXME: It isn't clear how to express a negative MSF code. Put zeros here for now.
-                            result.extend_from_slice(&[0, 0, 0, 0]);
+                            // (during the pregap, the relative time will count down to 0)
+                            result.extend_from_slice(&self.msf_to_address_field(
+                                Msf::from_sector((-rel_time).try_into().unwrap())?,
+                                msf != 0,
+                            ));
                         } else {
                             // Track relative position is negative (LBA).
                             // [MMC4] 6.29.3.3:
                             // If the CDB TIME bit is zero, this field is a track relative LBA. If the current block is in
                             // the pre-gap area of a track, this is a negative value, expressed as a twoís-complement number.
-                            result.extend_from_slice(&track_relative.to_be_bytes());
+                            result.extend_from_slice(&rel_time.to_be_bytes());
                         }
                     }
                     _ => {
@@ -1121,11 +1313,21 @@ impl ScsiTarget for ScsiTargetCdrom {
                     return Ok(ScsiCmdResult::Status(STATUS_CHECK_CONDITION));
                 }
 
-                let start_track = self.get_track_at_sector(start_sector);
-                if start_track
-                    .map(|t| t.control != AUDIO_TRACK)
-                    .unwrap_or(false)
-                {
+                let initial_sector = match backend.read_cdda_sector(start_sector) {
+                    Ok(s) => s,
+                    Err(CdromError::CheckCondition(key, asc)) => {
+                        self.common.set_cc(key, asc);
+                        return Ok(ScsiCmdResult::Status(STATUS_CHECK_CONDITION));
+                    }
+                    Err(CdromError::BackendDead) => {
+                        self.eject_media();
+                        self.common.set_cc(CC_KEY_NOT_READY, ASC_MEDIUM_NOT_PRESENT);
+                        return Ok(ScsiCmdResult::Status(STATUS_CHECK_CONDITION));
+                    }
+                    Err(CdromError::Other(e)) => return Err(e),
+                };
+
+                if !initial_sector.qsub.is_audio() {
                     // [MMC4] 6.17.2.3:
                     // If the address is not within an audio track the command shall be terminated with
                     // CHECK CONDITION status and SK/ASC/ASCQ values shall be set to ILLEGAL REQUEST/ILLEGAL
@@ -1134,6 +1336,10 @@ impl ScsiTarget for ScsiTargetCdrom {
                     self.common
                         .set_cc(CC_KEY_ILLEGAL_REQUEST, ASC_ILLEGAL_MODE_FOR_THIS_TRACK);
                     return Ok(ScsiCmdResult::Status(STATUS_CHECK_CONDITION));
+                }
+
+                if initial_sector.qsub.adr() == 1 {
+                    self.curr_mode1_qsub = initial_sector.qsub;
                 }
 
                 self.audio_pos = start_sector;
@@ -1305,12 +1511,8 @@ impl ScsiTarget for ScsiTargetCdrom {
                     if self.audio_clock >= CLOCK_SPEED / AUDIO_SECTORS_PER_SEC as u64 {
                         self.audio_clock -= CLOCK_SPEED / AUDIO_SECTORS_PER_SEC as u64;
 
-                        if self.audio_pos >= self.audio_stop {
-                            self.audio_state = AudioState::Stopped;
-                            self.audio_clock = 0;
-                        } else {
-                            self.audio_pos += 1;
-                        }
+                        self.audio_pos += 1;
+                        self.resolve_audio_pos();
                     }
 
                     Ok(())

--- a/frontend_egui/src/app.rs
+++ b/frontend_egui/src/app.rs
@@ -1447,6 +1447,20 @@ impl SnowGui {
                                     self.cdrom_files_dialog
                                         .pick_multiple(self.settings.native_file_dialogs);
                                 }
+                                if let Some(physical_drives) = snow_core::mac::scsi::cdrom::backends::query_physical_cdrom_drives() {
+                                    ui.menu_button("Mount physical CD-ROM drive", |ui| {
+                                        ui.set_min_width(Self::SUBMENU_WIDTH);
+                                        for drive in &physical_drives {
+                                            if ui.button(&drive.friendly_name).clicked() {
+                                                log::info!("Mounting drive at path {}", drive.path.to_str().unwrap());
+                                                self.emu.scsi_load_cdrom(id, &drive.path);
+                                            }
+                                        }
+                                        if physical_drives.is_empty() {
+                                            ui.weak("No physical CD-ROM drives available");
+                                        }
+                                    });
+                                }
                                 if show_detach {
                                     ui.separator();
                                     if ui.button("Detach CD-ROM drive").clicked() {


### PR DESCRIPTION
This PR implements the ability to mount a physical CD-ROM drive so real discs can be accessed in Snow. Get out your old CD-ROM collection! This feature is only implemented for Windows at this time.

Features:

- [x] Support mounting and opening a data CD
- [x] Support mounting and playing an audio CD
- [x] Support mounting and playing an Enhanced CD
- [x] Add a menu for listing and selecting physical drives
- [x] Handle semi-gracefully if the user ejects the CD

Known issues:

- The emulator will briefly freeze on each access. Snow can't (yet) do anything else while a SCSI read is in progress.

Notes:

- On classic Macs, discs were locked in the drive and could only be ejected by dragging the disc icon to the trash. That behavior is _not_ implemented here. While drive locking is technically possible, I'm very hesitant to use it as it breaks modern users' expectations too much.
- Ejecting the CD or unplugging the drive will cause Mac OS to complain with read failures and "device not ready" errors, but it (usually) won't crash and you can mount a disc again.
- This feature is implemented for Windows only. I don't have access to a Mac or Linux machine for testing.