### PR TITLE
Never discard a new frame; reduces lag

### DIFF
--- a/core/src/emulator/mod.rs
+++ b/core/src/emulator/mod.rs
@@ -256,7 +256,7 @@ impl Emulator {
         rom: &[u8],
         extra_roms: &[ExtraROMs],
         model: MacModel,
-    ) -> Result<(Self, crossbeam_channel::Receiver<DisplayBuffer>)> {
+    ) -> Result<(Self, Arc<Mutex<Option<DisplayBuffer>>>)> {
         Self::new_with_extra(
             rom,
             extra_roms,
@@ -281,7 +281,7 @@ impl Emulator {
         override_fdd_type: Option<DriveType>,
         pmmu_enabled: bool,
         shared_dir: Option<PathBuf>,
-    ) -> Result<(Self, crossbeam_channel::Receiver<DisplayBuffer>)> {
+    ) -> Result<(Self, Arc<Mutex<Option<DisplayBuffer>>>)> {
         // Set up channels
         let (cmds, cmdr) = crossbeam_channel::unbounded();
         let (statuss, statusr) = crossbeam_channel::unbounded();
@@ -469,7 +469,7 @@ impl Emulator {
     pub fn load_state<P: AsRef<Path>, PT: AsRef<Path>>(
         path: P,
         tmpdir: PT,
-    ) -> Result<(Self, crossbeam_channel::Receiver<DisplayBuffer>)> {
+    ) -> Result<(Self, Arc<Mutex<Option<DisplayBuffer>>>)> {
         let (cmds, cmdr) = crossbeam_channel::unbounded();
         let (statuss, statusr) = crossbeam_channel::unbounded();
         let renderer = ChannelRenderer::new(0, 0)?;

--- a/core/src/mac/nubus/mdc12.rs
+++ b/core/src/mac/nubus/mdc12.rs
@@ -389,10 +389,10 @@ where
 {
     fn tick(&mut self, ticks: Ticks, _: ()) -> Result<Ticks> {
         self.vblank_ticks += ticks;
-        if self.vblank_ticks > 16_000_000 / 60 {
+        if self.vblank_ticks >= 16_000_000 / 60 {
             self.render()?;
 
-            self.vblank_ticks = 0;
+            self.vblank_ticks -= 16_000_000 / 60;
             if self.vblank_enable {
                 self.vblank_irq = true;
             }

--- a/core/src/mac/nubus/se30video.rs
+++ b/core/src/mac/nubus/se30video.rs
@@ -145,10 +145,10 @@ where
         if !self.vblank_enable {
             self.vblank_irq = false;
         }
-        if self.vblank_ticks > 16_000_000 / 60 {
+        if self.vblank_ticks >= 16_000_000 / 60 {
             self.render()?;
 
-            self.vblank_ticks = 0;
+            self.vblank_ticks -= 16_000_000 / 60;
             if self.vblank_enable {
                 self.vblank_irq = true;
             }

--- a/core/src/renderer/channel.rs
+++ b/core/src/renderer/channel.rs
@@ -1,29 +1,27 @@
+use std::sync::{Arc, Mutex};
+
 use anyhow::Result;
-use crossbeam_channel::{Receiver, Sender, TrySendError};
 
 use super::{DisplayBuffer, Renderer};
 
 /// A renderer that feeds it display buffer back over a channel.
 pub struct ChannelRenderer {
     displaybuffer: DisplayBuffer,
-    sender: Sender<DisplayBuffer>,
-    receiver: Receiver<DisplayBuffer>,
+    channel: Arc<Mutex<Option<DisplayBuffer>>>,
 }
 
 impl ChannelRenderer {
-    pub fn get_receiver(&self) -> Receiver<DisplayBuffer> {
-        self.receiver.clone()
+    pub fn get_receiver(&self) -> Arc<Mutex<Option<DisplayBuffer>>> {
+        self.channel.clone()
     }
 }
 
 impl Renderer for ChannelRenderer {
     /// Creates a new renderer with a screen of the given size
     fn new(width: u16, height: u16) -> Result<Self> {
-        let (sender, receiver) = crossbeam_channel::bounded(1);
         Ok(Self {
             displaybuffer: DisplayBuffer::new(width, height),
-            sender,
-            receiver,
+            channel: Default::default(),
         })
     }
 
@@ -35,10 +33,7 @@ impl Renderer for ChannelRenderer {
     fn update(&mut self) -> Result<()> {
         let new_buffer = self.displaybuffer.new_from_this();
         let buffer = std::mem::replace(&mut self.displaybuffer, new_buffer);
-
-        match self.sender.try_send(buffer) {
-            Err(TrySendError::Full(_)) => Ok(()),
-            e => Ok(e?),
-        }
+        *self.channel.lock().unwrap() = Some(buffer);
+        Ok(())
     }
 }

--- a/frontend_egui/src/emulator.rs
+++ b/frontend_egui/src/emulator.rs
@@ -1,7 +1,6 @@
 //! Emulator state management
 
 use anyhow::{anyhow, Result};
-use crossbeam_channel::Receiver;
 use eframe::egui;
 use log::*;
 use num_traits::cast::ToPrimitive;
@@ -67,7 +66,7 @@ impl From<Option<ScsiTargetStatus>> for ScsiTarget {
 
 /// Results of initializing the emulator, includes channels
 pub struct EmulatorInitResult {
-    pub frame_receiver: Receiver<DisplayBuffer>,
+    pub frame_receiver: Arc<Mutex<Option<DisplayBuffer>>>,
 }
 
 /// Initialization arguments for the emulator, minus filenames
@@ -314,7 +313,7 @@ impl EmulatorState {
     fn init_finalize(
         &mut self,
         mut emulator: Emulator,
-        frame_recv: crossbeam_channel::Receiver<DisplayBuffer>,
+        frame_recv: Arc<Mutex<Option<DisplayBuffer>>>,
         cmd: EmulatorCommandSender,
         audio_disabled: bool,
         pause: bool,

--- a/frontend_egui/src/widgets/framebuffer.rs
+++ b/frontend_egui/src/widgets/framebuffer.rs
@@ -5,7 +5,6 @@ use std::{fs::File, path::Path};
 
 use crate::shader_pipeline::{ShaderConfig, ShaderId, ShaderPipeline};
 use anyhow::{bail, Result};
-use crossbeam_channel::Receiver;
 use eframe::egui;
 use eframe::egui::Vec2;
 use eframe::egui_glow;
@@ -43,7 +42,7 @@ impl Display for ScalingAlgorithm {
 
 pub struct FramebufferWidget {
     frame: Option<DisplayBuffer>,
-    frame_recv: Option<Receiver<DisplayBuffer>>,
+    frame_recv: Option<Arc<std::sync::Mutex<Option<DisplayBuffer>>>>,
     viewport_texture: egui::TextureHandle,
     pub scale: f32,
     pub scaling_algorithm: ScalingAlgorithm,
@@ -100,15 +99,16 @@ impl FramebufferWidget {
         f32::from(self.display_size[1]) * self.scale
     }
 
-    pub fn connect_receiver(&mut self, recv: Receiver<DisplayBuffer>) {
+    pub fn connect_receiver(&mut self, recv: Arc<std::sync::Mutex<Option<DisplayBuffer>>>) {
         self.frame_recv = Some(recv);
     }
 
     pub fn draw(&mut self, ui: &mut egui::Ui, fullscreen: bool) -> egui::Response {
         if let Some(ref frame_recv) = self.frame_recv {
-            if !frame_recv.is_empty() {
-                let frame = frame_recv.recv().unwrap();
-
+            if let Some(frame) = {
+                let mut lock = frame_recv.lock().unwrap();
+                lock.take()
+            } {
                 self.display_size = [frame.width(), frame.height()];
                 self.viewport_texture.set(
                     egui::ColorImage::new(

--- a/testrunner/src/bin/single/main.rs
+++ b/testrunner/src/bin/single/main.rs
@@ -132,7 +132,10 @@ fn main() -> Result<()> {
     info!("Starting");
     let start = Instant::now();
     while emulator.get_cycles() < args.cycles {
-        while let Ok(buf) = frame_recv.try_recv() {
+        while let Some(buf) = {
+            let mut lock = frame_recv.lock().unwrap();
+            lock.take()
+        } {
             assert!(display_height == 0 || display_height == buf.height());
             assert!(display_width == 0 || display_width == buf.width());
             display_height = buf.height();


### PR DESCRIPTION
Currently we use a crossbeam channel to push frames to the display. If the channel is full, any new frames generated by the emulator are discarded. Once a message is sent through a crossbeam channel, there is no way to replace or update it.

This PR replaces the crossbeam channel with a simple shared buffer, so the display always receives the latest available frame. Display lag is slightly reduced.