### PR TITLE
Move MacRoman encoding helpers to core crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -265,7 +265,7 @@ dependencies = [
  "objc2-foundation 0.3.1",
  "parking_lot",
  "percent-encoding",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
  "x11rb",
 ]
 
@@ -4667,6 +4667,7 @@ dependencies = [
  "thiserror 1.0.69",
  "tun",
  "typetag",
+ "unicode-normalization",
  "zstd",
 ]
 
@@ -5063,6 +5064,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "tokio"
 version = "1.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5263,6 +5279,15 @@ name = "unicode-ident"
 version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
 
 [[package]]
 name = "unicode-segmentation"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -58,6 +58,7 @@ hex = "0.4.3"
 arpfloat = { version = "0.1.11", default-features = false, features = ["std"] }
 serde-big-array = "0.5.1"
 typetag = "0.2.20"
+unicode-normalization = "0.1.24"
 postcard = { version = "1.1.3", features = ["use-std"], optional = true }
 binrw = { version = "0.15.0", optional = true }
 zstd = { version = "0.13.3", optional = true }

--- a/core/src/mac/scsi/toolbox.rs
+++ b/core/src/mac/scsi/toolbox.rs
@@ -14,6 +14,7 @@ use std::path::PathBuf;
 use log::*;
 
 use super::{STATUS_CHECK_CONDITION, STATUS_GOOD, ScsiCmdResult};
+use crate::util::mac::{macroman_to_utf8, utf8_to_macroman};
 
 const MAX_FILE_PATH: usize = 32; // Max Macintosh File name length
 
@@ -130,7 +131,7 @@ impl BlueSCSI {
                 file_entry[0] = index;
                 file_entry[1] = if is_dir { 0x00 } else { 0x01 };
 
-                let name_bytes = name_str.as_bytes();
+                let name_bytes = utf8_to_macroman(name_str);
                 let len = name_bytes.len().min(MAX_FILE_PATH);
                 file_entry[2..2 + len].copy_from_slice(&name_bytes[..len]);
 
@@ -185,9 +186,8 @@ impl BlueSCSI {
             return ScsiCmdResult::Status(STATUS_CHECK_CONDITION);
         };
         if let Some(data) = outdata {
-            if let Some(pos) = data.iter().position(|&b| b == 0)
-                && let Ok(name) = std::str::from_utf8(&data[..pos])
-            {
+            if let Some(pos) = data.iter().position(|&b| b == 0) {
+                let name = macroman_to_utf8(&data[..pos]);
                 let path = shared_dir.join(name);
                 match File::create(path) {
                     Ok(f) => {

--- a/core/src/util/mac.rs
+++ b/core/src/util/mac.rs
@@ -1,0 +1,61 @@
+//! Macintosh text encoding helpers.
+
+use std::collections::HashMap;
+use std::sync::OnceLock;
+use unicode_normalization::UnicodeNormalization;
+
+/// Converts a MacRoman-encoded byte slice to a UTF-8 string.
+pub fn macroman_to_utf8(bytes: &[u8]) -> String {
+    bytes
+        .iter()
+        .map(|&byte| match byte {
+            0x0D => '\n',
+            0x00..=0x7F => byte as char,
+            _ => MACROMAN_HIGH[(byte - 0x80) as usize],
+        })
+        .collect()
+}
+
+/// Converts a UTF-8 string into MacRoman bytes, replacing unsupported
+/// characters with `?`.
+pub fn utf8_to_macroman(text: &str) -> Vec<u8> {
+    let reverse_map = macroman_reverse_map();
+    text.nfc()
+        .map(|ch| match ch {
+            '\n' => 0x0D,
+            '\0'..='\u{7F}' => ch as u8,
+            _ => reverse_map.get(&ch).copied().unwrap_or(b'?'),
+        })
+        .collect()
+}
+
+fn macroman_reverse_map() -> &'static HashMap<char, u8> {
+    static REVERSE_MAP: OnceLock<HashMap<char, u8>> = OnceLock::new();
+    REVERSE_MAP.get_or_init(|| {
+        MACROMAN_HIGH
+            .iter()
+            .enumerate()
+            .map(|(idx, ch)| (*ch, idx as u8 + 0x80))
+            .collect()
+    })
+}
+
+#[rustfmt::skip]
+const MACROMAN_HIGH: [char; 128] = [
+    '\u{00C4}', '\u{00C5}', '\u{00C7}', '\u{00C9}', '\u{00D1}', '\u{00D6}', '\u{00DC}', '\u{00E1}',
+    '\u{00E0}', '\u{00E2}', '\u{00E4}', '\u{00E3}', '\u{00E5}', '\u{00E7}', '\u{00E9}', '\u{00E8}',
+    '\u{00EA}', '\u{00EB}', '\u{00ED}', '\u{00EC}', '\u{00EE}', '\u{00EF}', '\u{00F1}', '\u{00F3}',
+    '\u{00F2}', '\u{00F4}', '\u{00F6}', '\u{00F5}', '\u{00FA}', '\u{00F9}', '\u{00FB}', '\u{00FC}',
+    '\u{2020}', '\u{00B0}', '\u{00A2}', '\u{00A3}', '\u{00A7}', '\u{2022}', '\u{00B6}', '\u{00DF}',
+    '\u{00AE}', '\u{00A9}', '\u{2122}', '\u{00B4}', '\u{00A8}', '\u{2260}', '\u{00C6}', '\u{00D8}',
+    '\u{221E}', '\u{00B1}', '\u{2264}', '\u{2265}', '\u{00A5}', '\u{00B5}', '\u{2202}', '\u{2211}',
+    '\u{220F}', '\u{03C0}', '\u{222B}', '\u{00AA}', '\u{00BA}', '\u{03A9}', '\u{00E6}', '\u{00F8}',
+    '\u{00BF}', '\u{00A1}', '\u{00AC}', '\u{221A}', '\u{0192}', '\u{2248}', '\u{2206}', '\u{00AB}',
+    '\u{00BB}', '\u{2026}', '\u{00A0}', '\u{00C0}', '\u{00C3}', '\u{00D5}', '\u{0152}', '\u{0153}',
+    '\u{2013}', '\u{2014}', '\u{201C}', '\u{201D}', '\u{2018}', '\u{2019}', '\u{00F7}', '\u{25CA}',
+    '\u{00FF}', '\u{0178}', '\u{2044}', '\u{20AC}', '\u{2039}', '\u{203A}', '\u{FB01}', '\u{FB02}',
+    '\u{2021}', '\u{00B7}', '\u{201A}', '\u{201E}', '\u{2030}', '\u{00C2}', '\u{00CA}', '\u{00C1}',
+    '\u{00CB}', '\u{00C8}', '\u{00CD}', '\u{00CE}', '\u{00CF}', '\u{00CC}', '\u{00D3}', '\u{00D4}',
+    '\u{F8FF}', '\u{00D2}', '\u{00DA}', '\u{00DB}', '\u{00D9}', '\u{0131}', '\u{02C6}', '\u{02DC}',
+    '\u{00AF}', '\u{02D8}', '\u{02D9}', '\u{02DA}', '\u{00B8}', '\u{02DD}', '\u{02DB}', '\u{02C7}',
+];

--- a/core/src/util/mod.rs
+++ b/core/src/util/mod.rs
@@ -1,4 +1,5 @@
 pub mod lossyinto;
+pub mod mac;
 
 use std::ops::{Mul, SubAssign};
 use std::sync::{Arc, RwLock};

--- a/frontend_egui/src/util/mac.rs
+++ b/frontend_egui/src/util/mac.rs
@@ -1,40 +1,9 @@
 //! Macintosh helper functions
 
+use snow_core::util::mac::macroman_to_utf8;
 use std::fs::File;
 use std::io::{Read, Seek, SeekFrom};
 use std::path::Path;
-
-/// Converts a MacRoman-encoded byte slice to a UTF-8 string.
-pub fn macroman_to_utf8(bytes: &[u8]) -> String {
-    #[rustfmt::skip]
-    const MACROMAN_HIGH: [char; 128] = [
-        '\u{00C4}', '\u{00C5}', '\u{00C7}', '\u{00C9}', '\u{00D1}', '\u{00D6}', '\u{00DC}', '\u{00E1}',
-        '\u{00E0}', '\u{00E2}', '\u{00E4}', '\u{00E3}', '\u{00E5}', '\u{00E7}', '\u{00E9}', '\u{00E8}',
-        '\u{00EA}', '\u{00EB}', '\u{00ED}', '\u{00EC}', '\u{00EE}', '\u{00EF}', '\u{00F1}', '\u{00F3}',
-        '\u{00F2}', '\u{00F4}', '\u{00F6}', '\u{00F5}', '\u{00FA}', '\u{00F9}', '\u{00FB}', '\u{00FC}',
-        '\u{2020}', '\u{00B0}', '\u{00A2}', '\u{00A3}', '\u{00A7}', '\u{2022}', '\u{00B6}', '\u{00DF}',
-        '\u{00AE}', '\u{00A9}', '\u{2122}', '\u{00B4}', '\u{00A8}', '\u{2260}', '\u{00C6}', '\u{00D8}',
-        '\u{221E}', '\u{00B1}', '\u{2264}', '\u{2265}', '\u{00A5}', '\u{00B5}', '\u{2202}', '\u{2211}',
-        '\u{220F}', '\u{03C0}', '\u{222B}', '\u{00AA}', '\u{00BA}', '\u{03A9}', '\u{00E6}', '\u{00F8}',
-        '\u{00BF}', '\u{00A1}', '\u{00AC}', '\u{221A}', '\u{0192}', '\u{2248}', '\u{2206}', '\u{00AB}',
-        '\u{00BB}', '\u{2026}', '\u{00A0}', '\u{00C0}', '\u{00C3}', '\u{00D5}', '\u{0152}', '\u{0153}',
-        '\u{2013}', '\u{2014}', '\u{201C}', '\u{201D}', '\u{2018}', '\u{2019}', '\u{00F7}', '\u{25CA}',
-        '\u{00FF}', '\u{0178}', '\u{2044}', '\u{20AC}', '\u{2039}', '\u{203A}', '\u{FB01}', '\u{FB02}',
-        '\u{2021}', '\u{00B7}', '\u{201A}', '\u{201E}', '\u{2030}', '\u{00C2}', '\u{00CA}', '\u{00C1}',
-        '\u{00CB}', '\u{00C8}', '\u{00CD}', '\u{00CE}', '\u{00CF}', '\u{00CC}', '\u{00D3}', '\u{00D4}',
-        '\u{F8FF}', '\u{00D2}', '\u{00DA}', '\u{00DB}', '\u{00D9}', '\u{0131}', '\u{02C6}', '\u{02DC}',
-        '\u{00AF}', '\u{02D8}', '\u{02D9}', '\u{02DA}', '\u{00B8}', '\u{02DD}', '\u{02DB}', '\u{02C7}',
-    ];
-
-    bytes
-        .iter()
-        .map(|&b| match b {
-            0x0D => '\n',
-            0x00..=0x7F => b as char,
-            _ => MACROMAN_HIGH[(b - 0x80) as usize],
-        })
-        .collect()
-}
 
 /// Reads the TEXT scrap from a Classic Mac OS Scrap Manager RAM image.
 /// Returns `None` if the scrap is not in memory, empty, or contains no TEXT entry.


### PR DESCRIPTION
Allows them to be used in the BlueSCSI Toolbox implementation, so that (some) special characters in transferred file names can be preserved.

Also adds Unicode normalization to them so that they handle accents represented via combining characters.