### PR TITLE
ALU efficiency

### DIFF
--- a/core/src/cpu_m68k/alu.rs
+++ b/core/src/cpu_m68k/alu.rs
@@ -199,7 +199,8 @@ where
     pub(super) fn alu_asl<T: CpuSized>(value: T, count: u8, mut f: RegisterSR) -> (T, u8) {
         // Perform shift on a 64-bit value, since count is guaranteed to be in 0..=63.
         let zext_value: u64 = value.expand().into();
-        let sext_value: i64 = value.expand_signed().into();
+        // i128 is required to calculate the overflow flag
+        let sext_value: i128 = value.expand_signed().into();
 
         // Detect if the most significant bit changes at any time during the shift operation.
         let initial_upper_and_sign = sext_value >> (T::BITS - 1);

--- a/core/src/cpu_m68k/alu.rs
+++ b/core/src/cpu_m68k/alu.rs
@@ -172,97 +172,102 @@ where
     }
 
     /// Arithmetic right shift
-    pub(super) fn alu_asr<T: CpuSized>(mut value: T, count: usize, mut f: RegisterSR) -> (T, u8) {
-        let mut overflow = T::zero();
+    pub(super) fn alu_asr<T: CpuSized>(value: T, count: u8, mut f: RegisterSR) -> (T, u8) {
+        // Perform shift on a 64-bit value, since count is guaranteed to be in 0..=63.
+        let value: i64 = value.expand_signed().into();
 
-        f.set_c(false);
+        let carry = if count == 0 {
+            false
+        } else {
+            (value >> (count - 1)) & 1 != 0
+        };
 
-        for _ in 0..count {
-            let old = value;
-            let msb = value & T::msb() != T::zero();
+        let value = T::chop((value >> count) as Long);
 
-            f.set_c(value & T::one() != T::zero());
-
-            value >>= T::one();
-            if msb {
-                value |= T::msb();
-            }
-            overflow |= old ^ value;
-        }
-
-        f.set_v(overflow & T::msb() != T::zero());
+        f.set_c(carry);
+        f.set_v(false);
         f.set_z(value == T::zero());
         f.set_n(value & T::msb() != T::zero());
         if count != 0 {
-            f.set_x(f.c());
+            f.set_x(carry);
         }
+
         (value, f.ccr())
     }
 
     /// Arithmetic left shift
-    pub(super) fn alu_asl<T: CpuSized>(mut value: T, count: usize, mut f: RegisterSR) -> (T, u8) {
-        let mut overflow = T::zero();
+    pub(super) fn alu_asl<T: CpuSized>(value: T, count: u8, mut f: RegisterSR) -> (T, u8) {
+        // Perform shift on a 64-bit value, since count is guaranteed to be in 0..=63.
+        let zext_value: u64 = value.expand().into();
+        let sext_value: i64 = value.expand_signed().into();
 
-        f.set_c(false);
+        // Detect if the most significant bit changes at any time during the shift operation.
+        let initial_upper_and_sign = sext_value >> (T::BITS - 1);
+        let new_upper_and_sign = (sext_value << count) >> (T::BITS - 1);
+        let overflow = initial_upper_and_sign != new_upper_and_sign;
 
-        for _ in 0..count {
-            let old = value;
+        // Compute carry flag. Use the zero-extended value here to ensure C is correct if
+        // count == 0.
+        let value = zext_value << count;
+        let carry = value & (1u64 << T::BITS) != 0;
 
-            f.set_c(value & T::msb() != T::zero());
+        let value = T::chop(value as Long);
 
-            value <<= T::one();
-            overflow |= old ^ value;
-        }
-
-        f.set_v(overflow & T::msb() != T::zero());
+        f.set_c(carry);
+        f.set_v(overflow);
         f.set_z(value == T::zero());
         f.set_n(value & T::msb() != T::zero());
         if count != 0 {
-            f.set_x(f.c());
+            f.set_x(carry);
         }
         (value, f.ccr())
     }
 
     /// Logical left shift
-    pub(super) fn alu_lsl<T: CpuSized>(mut value: T, count: usize, mut f: RegisterSR) -> (T, u8) {
-        f.set_c(false);
+    pub(super) fn alu_lsl<T: CpuSized>(value: T, count: u8, mut f: RegisterSR) -> (T, u8) {
+        // Perform shift on a 64-bit value, since count is guaranteed to be in 0..=63.
+        let value: u64 = value.expand().into();
+
+        let value = value << count;
+        let carry = value & (1u64 << T::BITS) != 0;
+
+        let value = T::chop(value as Long);
+
+        f.set_c(carry);
         f.set_v(false);
-
-        for _ in 0..count {
-            f.set_c(value & T::msb() != T::zero());
-
-            value <<= T::one();
-        }
-
         f.set_z(value == T::zero());
         f.set_n(value & T::msb() != T::zero());
         if count != 0 {
-            f.set_x(f.c());
+            f.set_x(carry);
         }
         (value, f.ccr())
     }
 
     /// Logical right shift
-    pub(super) fn alu_lsr<T: CpuSized>(mut value: T, count: usize, mut f: RegisterSR) -> (T, u8) {
-        f.set_c(false);
+    pub(super) fn alu_lsr<T: CpuSized>(value: T, count: u8, mut f: RegisterSR) -> (T, u8) {
+        // Perform shift on a 64-bit value, since count is guaranteed to be in 0..=63.
+        let value: u64 = value.expand().into();
+
+        let carry = if count == 0 {
+            false
+        } else {
+            (value >> (count - 1)) & 1 != 0
+        };
+
+        let value = T::chop((value >> count) as Long);
+
+        f.set_c(carry);
         f.set_v(false);
-
-        for _ in 0..count {
-            f.set_c(value & T::one() != T::zero());
-
-            value >>= T::one();
-        }
-
         f.set_z(value == T::zero());
         f.set_n(value & T::msb() != T::zero());
         if count != 0 {
-            f.set_x(f.c());
+            f.set_x(carry);
         }
         (value, f.ccr())
     }
 
     /// Rotate left
-    pub(super) fn alu_rol<T: CpuSized>(mut value: T, count: usize, mut f: RegisterSR) -> (T, u8) {
+    pub(super) fn alu_rol<T: CpuSized>(mut value: T, count: u8, mut f: RegisterSR) -> (T, u8) {
         // For shift count 0, carry is cleared
         f.set_c(false);
 
@@ -282,7 +287,7 @@ where
     }
 
     /// Rotate right
-    pub(super) fn alu_ror<T: CpuSized>(mut value: T, count: usize, mut f: RegisterSR) -> (T, u8) {
+    pub(super) fn alu_ror<T: CpuSized>(mut value: T, count: u8, mut f: RegisterSR) -> (T, u8) {
         // For shift count 0, carry is cleared
         f.set_c(false);
 
@@ -302,7 +307,7 @@ where
     }
 
     /// Rotate left with extend
-    pub(super) fn alu_roxl<T: CpuSized>(mut value: T, count: usize, mut f: RegisterSR) -> (T, u8) {
+    pub(super) fn alu_roxl<T: CpuSized>(mut value: T, count: u8, mut f: RegisterSR) -> (T, u8) {
         for _ in 0..count {
             let x = f.x();
             f.set_x(value & T::msb() != T::zero());
@@ -321,7 +326,7 @@ where
     }
 
     /// Rotate right with extend
-    pub(super) fn alu_roxr<T: CpuSized>(mut value: T, count: usize, mut f: RegisterSR) -> (T, u8) {
+    pub(super) fn alu_roxr<T: CpuSized>(mut value: T, count: u8, mut f: RegisterSR) -> (T, u8) {
         for _ in 0..count {
             let x = f.x();
             f.set_x(value & T::one() != T::zero());

--- a/core/src/cpu_m68k/alu.rs
+++ b/core/src/cpu_m68k/alu.rs
@@ -4,7 +4,7 @@ use super::{CpuM68kType, CpuSized};
 use crate::cpu_m68k::FpuM68kType;
 
 use crate::bus::{Address, Bus, IrqSource};
-use crate::types::{Byte, Long, Word};
+use crate::types::{Byte, Long, MyIntTraits, Word};
 
 impl<
     TBus,
@@ -18,22 +18,17 @@ where
 {
     /// Add (a + b = c)
     pub(super) fn alu_add<T: CpuSized>(a: T, b: T, f: RegisterSR) -> (T, u8) {
-        let a = a.expand();
-        let b = b.expand();
-        let result: Long = a.wrapping_add(b);
-
-        let msb: Long = T::msb().into();
-        let carry: Long = a ^ b ^ result;
-        let overflow: Long = (a ^ result) & (b ^ result);
+        let (result, carry) = a.overflowing_add(b);
+        let (_, overflow) = a.cast_signed().overflowing_add(b.cast_signed());
 
         let mut new_f = f;
-        new_f.set_c((carry ^ overflow) & msb != 0);
-        new_f.set_x((carry ^ overflow) & msb != 0);
-        new_f.set_v(overflow & msb != 0);
-        new_f.set_n(result & msb != 0);
-        new_f.set_z(T::chop(result) == T::zero());
+        new_f.set_c(carry);
+        new_f.set_x(carry);
+        new_f.set_v(overflow);
+        new_f.set_n(result & T::msb() != T::zero());
+        new_f.set_z(result == T::zero());
 
-        (T::chop(result), new_f.ccr())
+        (result, new_f.ccr())
     }
 
     /// Add (a + b + x = c)
@@ -61,22 +56,17 @@ where
 
     /// Subtract (a - b = c)
     pub(super) fn alu_sub<T: CpuSized>(a: T, b: T, f: RegisterSR) -> (T, u8) {
-        let a = a.expand();
-        let b = b.expand();
-        let result: Long = a.wrapping_sub(b);
-
-        let msb: Long = T::msb().into();
-        let carry: Long = a ^ b ^ result;
-        let overflow: Long = (a ^ result) & (b ^ a);
+        let (result, carry) = a.overflowing_sub(b);
+        let (_, overflow) = a.cast_signed().overflowing_sub(b.cast_signed());
 
         let mut new_f = f;
-        new_f.set_c((carry ^ overflow) & msb != 0);
-        new_f.set_x((carry ^ overflow) & msb != 0);
-        new_f.set_v(overflow & msb != 0);
-        new_f.set_n(result & msb != 0);
-        new_f.set_z(T::chop(result) == T::zero());
+        new_f.set_c(carry);
+        new_f.set_x(carry);
+        new_f.set_v(overflow);
+        new_f.set_n(result & T::msb() != T::zero());
+        new_f.set_z(result == T::zero());
 
-        (T::chop(result), new_f.ccr())
+        (result, new_f.ccr())
     }
 
     /// Subtract with extend (a - b - x = c)

--- a/core/src/cpu_m68k/cpu.rs
+++ b/core/src/cpu_m68k/cpu.rs
@@ -2975,11 +2975,11 @@ where
     fn op_shrot<T: CpuSized>(
         &mut self,
         instr: &Instruction,
-        calcfn: fn(T, usize, RegisterSR) -> (T, u8),
+        calcfn: fn(T, u8, RegisterSR) -> (T, u8),
     ) -> Result<()> {
         let count = match instr.get_sh_count() {
-            Either::Left(i) => i as usize,
-            Either::Right(r) => (self.regs.read::<Long>(r) % 64) as usize,
+            Either::Left(i) => i,
+            Either::Right(r) => (self.regs.read::<Long>(r) % 64) as u8,
         };
 
         self.prefetch_pump()?;
@@ -3003,7 +3003,7 @@ where
     fn op_shrot_ea(
         &mut self,
         instr: &Instruction,
-        calcfn: fn(Word, usize, RegisterSR) -> (Word, u8),
+        calcfn: fn(Word, u8, RegisterSR) -> (Word, u8),
     ) -> Result<()> {
         let value = self.read_ea::<Word>(instr, instr.get_op2())?;
 

--- a/core/src/cpu_m68k/cpu.rs
+++ b/core/src/cpu_m68k/cpu.rs
@@ -1660,7 +1660,8 @@ where
     ) -> Result<()> {
         let b = self
             .read_ea_hold::<T>(instr, instr.get_op2())?
-            .expand_sign_extend();
+            .expand_signed()
+            .cast_unsigned();
         self.ea_commit();
         let a: Long = self.regs.read_a(instr.get_op1());
         let (result, _) = calcfn(a, b, self.regs.sr);
@@ -1844,7 +1845,8 @@ where
     fn op_cmp_address<T: CpuSized>(&mut self, instr: &Instruction) -> Result<()> {
         let b = self
             .read_ea::<T>(instr, instr.get_op2())?
-            .expand_sign_extend();
+            .expand_signed()
+            .cast_unsigned();
         let a: Long = self.regs.read_a(instr.get_op1());
 
         let (_, ccr) = Self::alu_sub(a, b, self.regs.sr);
@@ -2336,7 +2338,7 @@ where
     fn op_ext<T: CpuSized, U: CpuSized>(&mut self, instr: &Instruction) -> Result<()> {
         // T: dest type, U: src type
         let value: U = self.read_ea(instr, instr.get_op2())?;
-        let result = T::chop(value.expand_sign_extend());
+        let result = T::chop(value.expand_signed().cast_unsigned());
 
         self.regs.sr.set_n(result & T::msb() != T::zero());
         self.regs.sr.set_v(false);
@@ -2625,7 +2627,7 @@ where
             AddressingMode::AbsoluteShort => {
                 self.advance_cycles(2)?;
                 self.regs.pc = self.regs.pc.wrapping_add(2) & ADDRESS_MASK;
-                self.fetch()?.expand_sign_extend()
+                self.fetch()?.expand_signed().cast_unsigned()
             }
             AddressingMode::AbsoluteLong => {
                 let h = self.fetch()? as Address;
@@ -2682,7 +2684,7 @@ where
             }
 
             let v = self.read_ticks::<T>(addr)?;
-            self.regs.write(reg, v.expand_sign_extend());
+            self.regs.write(reg, v.expand_signed().cast_unsigned());
 
             if instr.get_addr_mode()? != AddressingMode::IndirectPreDec {
                 addr = addr.wrapping_add(std::mem::size_of::<T>() as Address);
@@ -2740,10 +2742,8 @@ where
 
     /// CHK
     fn op_chk<T: CpuSized>(&mut self, instr: &Instruction) -> Result<()> {
-        let max = self
-            .read_ea::<T>(instr, instr.get_op2())?
-            .expand_sign_extend() as i32;
-        let value = self.regs.read_d::<T>(instr.get_op1()).expand_sign_extend() as i32;
+        let max = self.read_ea::<T>(instr, instr.get_op2())?.expand_signed();
+        let value = self.regs.read_d::<T>(instr.get_op1()).expand_signed();
 
         let (_result, ccr) =
             Self::alu_sub::<T>(T::chop(max as u32), T::chop(value as u32), self.regs.sr);
@@ -2944,7 +2944,7 @@ where
 
     /// MOVEQ
     fn op_moveq(&mut self, instr: &Instruction) -> Result<()> {
-        let value: Long = (instr.data as u8).expand_sign_extend();
+        let value: Long = (instr.data as u8).expand_signed().cast_unsigned();
 
         self.regs.write_d(instr.get_op1(), value);
 
@@ -3091,7 +3091,7 @@ where
             if is_addr_reg {
                 // Memory to address register - sign extend
                 self.regs
-                    .write_a(reg_num as usize, value.expand_sign_extend());
+                    .write_a(reg_num as usize, value.expand_signed().cast_unsigned());
             } else {
                 // Memory to data register
                 self.regs.write_d::<T>(reg_num as usize, value);
@@ -3128,7 +3128,7 @@ where
     /// RTD
     fn op_rtd(&mut self, _instr: &Instruction) -> Result<()> {
         // Bus access and cycles are an approximation based on UM/PRM
-        let displacement = self.fetch()?.expand_sign_extend() as i32;
+        let displacement = self.fetch()?.expand_signed();
         let pc = self.read_ticks(self.regs.read_a(7))?;
         let sp = self.regs.read_a::<Address>(7);
         self.regs

--- a/core/src/cpu_m68k/ea.rs
+++ b/core/src/cpu_m68k/ea.rs
@@ -223,10 +223,10 @@ where
                         self.read_ticks(disp_addr)?
                     }
                     MemoryIndirectAction::Word => {
-                        let od = self.fetch_pump()?.expand_sign_extend();
+                        let od = self.fetch_pump()?.expand_signed();
 
                         self.read_ticks::<Address>(disp_addr)?
-                            .wrapping_add_signed(od as i32)
+                            .wrapping_add_signed(od)
                     }
                     MemoryIndirectAction::Long => {
                         let mut od = Long::from(self.fetch_pump()?) << 16;
@@ -238,10 +238,10 @@ where
                         .read_ticks::<Address>(disp_addr)?
                         .wrapping_add(index.wrapping_mul(u32::from(scale))),
                     MemoryIndirectAction::PostIndexWord => {
-                        let od = self.fetch_pump()?.expand_sign_extend();
+                        let od = self.fetch_pump()?.expand_signed();
                         self.read_ticks::<Address>(disp_addr)?
                             .wrapping_add(index.wrapping_mul(u32::from(scale)))
-                            .wrapping_add_signed(od as i32)
+                            .wrapping_add_signed(od)
                     }
                     MemoryIndirectAction::PostIndexLong => {
                         let mut od = Long::from(self.fetch_pump()?) << 16;
@@ -252,10 +252,10 @@ where
                     }
                     MemoryIndirectAction::PreIndexNull => self.read_ticks(pre_addr)?,
                     MemoryIndirectAction::PreIndexWord => {
-                        let od = self.fetch_pump()?.expand_sign_extend();
+                        let od = self.fetch_pump()?.expand_signed();
 
                         self.read_ticks::<Address>(pre_addr)?
-                            .wrapping_add_signed(od as i32)
+                            .wrapping_add_signed(od)
                     }
                     MemoryIndirectAction::PreIndexLong => {
                         let mut od = Long::from(self.fetch_pump()?) << 16;

--- a/core/src/cpu_m68k/instruction.rs
+++ b/core/src/cpu_m68k/instruction.rs
@@ -997,10 +997,10 @@ impl Instruction {
     }
 
     /// Retrieves shift count/register for the rotate/shift instructions
-    pub fn get_sh_count(&self) -> Either<Long, Register> {
-        let rotation = (self.data >> 9) & 0b111;
+    pub fn get_sh_count(&self) -> Either<u8, Register> {
+        let rotation = ((self.data >> 9) & 0b111) as u8;
         match (self.data >> 5) & 1 {
-            0 => Either::Left(if rotation == 0 { 8 } else { rotation.into() }),
+            0 => Either::Left(if rotation == 0 { 8 } else { rotation }),
             1 => Either::Right(Register::Dn(rotation.into())),
             _ => unreachable!(),
         }

--- a/core/src/cpu_m68k/mod.rs
+++ b/core/src/cpu_m68k/mod.rs
@@ -10,10 +10,10 @@ pub mod regs;
 #[cfg(test)]
 pub mod tests;
 
-use num_traits::{FromBytes, PrimInt, ToBytes, WrappingAdd, WrappingShl, WrappingShr};
+use num_traits::{FromBytes, ToBytes, WrappingAdd, WrappingShl, WrappingShr};
 
 use crate::bus::Address;
-use crate::types::Long;
+use crate::types::{Long, MyUIntTraits, SignedLong};
 use crate::util::lossyinto::LossyInto;
 
 /// Motorola 68000
@@ -55,7 +55,7 @@ pub const FPU_M68882: FpuM68kType = 68882;
 /// Word (u16)
 /// Long (u32)
 pub trait CpuSized:
-    PrimInt
+    MyUIntTraits
     + FromBytes
     + ToBytes
     + WrappingAdd
@@ -69,12 +69,14 @@ pub trait CpuSized:
     + std::ops::ShlAssign
     + std::ops::ShrAssign
 {
+    const BITS: usize;
+
     /// Expands the value in the generic to a full register's width
     fn expand(self) -> Long;
 
     /// Expands the value in the generic to a full register's width,
     /// with sign extension.
-    fn expand_sign_extend(self) -> Long;
+    fn expand_signed(self) -> SignedLong;
 
     /// Replaces the lower bytes of the given value for types < Long
     /// or the full value for Long.
@@ -89,7 +91,7 @@ pub trait CpuSized:
 
 impl<T> CpuSized for T
 where
-    T: PrimInt
+    T: MyUIntTraits
         + FromBytes
         + ToBytes
         + WrappingAdd
@@ -106,6 +108,8 @@ where
     <T as ToBytes>::Bytes: AsMut<[u8]>,
     T: FromBytes<Bytes = <T as ToBytes>::Bytes>,
 {
+    const BITS: usize = std::mem::size_of::<T>() * 8;
+
     #[inline(always)]
     fn replace_in(self, value: Long) -> Long {
         let mask = match std::mem::size_of::<T>() {
@@ -123,18 +127,8 @@ where
     }
 
     #[inline(always)]
-    fn expand_sign_extend(self) -> Long {
-        let l = self.expand();
-        if l & T::msb().expand() != 0 {
-            match std::mem::size_of::<T>() {
-                1 => l | 0xFFFFFF00,
-                2 => l | 0xFFFF0000,
-                4 => l,
-                _ => unreachable!(),
-            }
-        } else {
-            l
-        }
+    fn expand_signed(self) -> SignedLong {
+        self.cast_signed().into()
     }
 
     #[inline(always)]
@@ -144,8 +138,7 @@ where
 
     #[inline(always)]
     fn msb() -> Self {
-        let shift = std::mem::size_of::<T>() * 8 - 1;
-        T::one() << shift
+        T::one() << (Self::BITS - 1)
     }
 }
 

--- a/core/src/cpu_m68k/regs.rs
+++ b/core/src/cpu_m68k/regs.rs
@@ -334,7 +334,7 @@ impl RegisterFile {
     /// Write an An register
     pub fn write_a<T: CpuSized>(&mut self, a: usize, val: T) {
         // Writes to A as Byte or Word are sign extended
-        let adj_val = val.expand_sign_extend();
+        let adj_val = val.expand_signed().cast_unsigned();
 
         if a == 7 {
             if self.sr.supervisor() {

--- a/core/src/types.rs
+++ b/core/src/types.rs
@@ -1,3 +1,4 @@
+use num::PrimInt;
 use proc_bitfield::bitfield;
 use serde::{Deserialize, Serialize};
 
@@ -12,9 +13,117 @@ pub struct MouseEvent {
 pub type AudioSampleSender = crossbeam_channel::Sender<u8>;
 
 pub type Byte = u8;
+pub type SignedByte = i8;
 pub type Word = u16;
+pub type SignedWord = i16;
 pub type Long = u32;
+pub type SignedLong = i32;
 pub type DoubleLong = u64;
+
+pub trait MyIntTraits: PrimInt {
+    /// See `u32::overflowing_add`
+    fn overflowing_add(self, rhs: Self) -> (Self, bool);
+
+    /// See `u32::overflowing_sub`
+    fn overflowing_sub(self, rhs: Self) -> (Self, bool);
+}
+
+impl MyIntTraits for Byte {
+    fn overflowing_add(self, rhs: Self) -> (Self, bool) {
+        self.overflowing_add(rhs)
+    }
+
+    fn overflowing_sub(self, rhs: Self) -> (Self, bool) {
+        self.overflowing_sub(rhs)
+    }
+}
+
+impl MyIntTraits for SignedByte {
+    fn overflowing_add(self, rhs: Self) -> (Self, bool) {
+        self.overflowing_add(rhs)
+    }
+
+    fn overflowing_sub(self, rhs: Self) -> (Self, bool) {
+        self.overflowing_sub(rhs)
+    }
+}
+
+impl MyIntTraits for Word {
+    fn overflowing_add(self, rhs: Self) -> (Self, bool) {
+        self.overflowing_add(rhs)
+    }
+
+    fn overflowing_sub(self, rhs: Self) -> (Self, bool) {
+        self.overflowing_sub(rhs)
+    }
+}
+
+impl MyIntTraits for SignedWord {
+    fn overflowing_add(self, rhs: Self) -> (Self, bool) {
+        self.overflowing_add(rhs)
+    }
+
+    fn overflowing_sub(self, rhs: Self) -> (Self, bool) {
+        self.overflowing_sub(rhs)
+    }
+}
+
+impl MyIntTraits for Long {
+    fn overflowing_add(self, rhs: Self) -> (Self, bool) {
+        self.overflowing_add(rhs)
+    }
+
+    fn overflowing_sub(self, rhs: Self) -> (Self, bool) {
+        self.overflowing_sub(rhs)
+    }
+}
+
+impl MyIntTraits for SignedLong {
+    fn overflowing_add(self, rhs: Self) -> (Self, bool) {
+        self.overflowing_add(rhs)
+    }
+
+    fn overflowing_sub(self, rhs: Self) -> (Self, bool) {
+        self.overflowing_sub(rhs)
+    }
+}
+
+pub trait MyUIntTraits: MyIntTraits {
+    type Signed: MySIntTraits;
+
+    /// Reinterpret the bits of this value as a signed integer
+    fn cast_signed(self) -> Self::Signed;
+}
+
+impl MyUIntTraits for Byte {
+    type Signed = SignedByte;
+
+    fn cast_signed(self) -> Self::Signed {
+        self.cast_signed()
+    }
+}
+
+impl MyUIntTraits for Word {
+    type Signed = SignedWord;
+
+    fn cast_signed(self) -> Self::Signed {
+        self.cast_signed()
+    }
+}
+
+impl MyUIntTraits for Long {
+    type Signed = SignedLong;
+
+    fn cast_signed(self) -> Self::Signed {
+        self.cast_signed()
+    }
+}
+
+pub trait MySIntTraits: MyIntTraits + std::convert::Into<SignedLong> {}
+
+impl MySIntTraits for SignedByte {}
+impl MySIntTraits for SignedWord {}
+impl MySIntTraits for SignedLong {}
 
 bitfield! {
     /// General purpose 16-bit field


### PR DESCRIPTION
This PR reworks some ALU instructions.

- Add and sub use Rust overflowing_add and overflowing_sub methods
- Shift instructions no longer shift one bit at a time

Admittedly, this doesn't have much effect on performance, but it's nice to have, right?

In my testing I haven't seen any problems. Snooper 2.0 CPU tests pass.