### PR TITLE
Fix offset not aligned to block when reading CD-ROM sectors

### DIFF
--- a/core/src/mac/scsi/cdrom/backends/cuesheet.rs
+++ b/core/src/mac/scsi/cdrom/backends/cuesheet.rs
@@ -7,9 +7,12 @@ use std::{
     str::Chars,
 };
 
-use crate::mac::scsi::cdrom::{
-    AUDIO_TRACK, CdromBackend, DATA_TRACK, LBA_START_SECTOR, Msf, RAW_SECTOR_LEN, SessionInfo,
-    TrackInfo,
+use crate::mac::scsi::{
+    ASC_UNRECOVERED_READ_ERROR, CC_KEY_MEDIUM_ERROR,
+    cdrom::{
+        AUDIO_TRACK, CdromBackend, CdromError, DATA_TRACK, LBA_START_SECTOR, Msf, RAW_SECTOR_LEN,
+        SessionInfo, TrackInfo,
+    },
 };
 
 // .cue file reference:
@@ -359,21 +362,49 @@ impl CdromBackend for CuesheetCdromBackend {
         333_000 * 2048
     }
 
-    fn read_bytes(&self, offset: usize, length: usize) -> Result<Vec<u8>> {
+    fn read_bytes(&self, offset: usize, length: usize) -> Result<Vec<u8>, CdromError> {
         let mut result = Vec::<u8>::with_capacity(length);
 
         // TODO: uh-oh, do we need to support CD-ROM's where the data is in session 2?
         // Example: "Weird Al" Yankovic - Running With Scissors
-        // (the Weird Al disc also uses Form 2 sectors in its data track!)
-        let rel_sector: u32 = (offset / 2048).try_into().unwrap();
-        // FIXME: Does the drive automatically find the data track?
-        let mut sector = LBA_START_SECTOR + rel_sector;
+        // (the Weird Al disc also uses Mode 2 sectors in its data track!)
+        let mut sector: u32 =
+            LBA_START_SECTOR + u32::try_from(offset / 2048).map_err(|e| anyhow!(e))?;
+        let mut data_offset = offset % 2048;
         while result.len() < length {
+            // FIXME: read_raw_sector should return the track form (audio or data); this method
+            // should fail with ILLEGAL_MODE_FOR_THIS_TRACK if this isn't a data sector.
             let raw_sector = self.read_raw_sector(sector)?;
+
+            // Check sync field
+            if raw_sector[0..12] != *b"\x00\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x00" {
+                log::warn!("Failed to read sector {}: invalid sync field", sector);
+                return Err(CdromError::CheckCondition(
+                    CC_KEY_MEDIUM_ERROR,
+                    ASC_UNRECOVERED_READ_ERROR,
+                ));
+            }
+
+            // Check mode field
+            // TODO: support Mode 2 Form 1 sectors
+            if raw_sector[15] != 1 {
+                log::warn!(
+                    "Failed to read sector {}: unexpected mode field {}",
+                    sector,
+                    raw_sector[15]
+                );
+                return Err(CdromError::CheckCondition(
+                    CC_KEY_MEDIUM_ERROR,
+                    ASC_UNRECOVERED_READ_ERROR,
+                ));
+            }
+
+            // TODO: Check error detection codes?
+            let user_data = &raw_sector[16..][..2048];
+            result.extend_from_slice(&user_data[data_offset..]);
+
             sector += 1;
-            // TODO: Check sync, mode and error detection data?
-            let sector_data = &raw_sector[16..][..2048];
-            result.extend_from_slice(sector_data);
+            data_offset = 0;
         }
 
         result.truncate(length);

--- a/core/src/mac/scsi/cdrom/backends/iso.rs
+++ b/core/src/mac/scsi/cdrom/backends/iso.rs
@@ -2,7 +2,10 @@ use anyhow::{Result, bail};
 use std::path::Path;
 
 use crate::mac::scsi::{
-    cdrom::{CdromBackend, DATA_TRACK, LBA_START_SECTOR, RAW_SECTOR_LEN, SessionInfo, TrackInfo},
+    cdrom::{
+        CdromBackend, CdromError, DATA_TRACK, LBA_START_SECTOR, RAW_SECTOR_LEN, SessionInfo,
+        TrackInfo,
+    },
     disk_image::DiskImage,
 };
 
@@ -33,7 +36,7 @@ impl CdromBackend for IsoCdromBackend {
         self.image.byte_len()
     }
 
-    fn read_bytes(&self, offset: usize, length: usize) -> Result<Vec<u8>> {
+    fn read_bytes(&self, offset: usize, length: usize) -> Result<Vec<u8>, CdromError> {
         Ok(self.image.read_bytes(offset, length))
     }
 

--- a/core/src/mac/scsi/cdrom/mod.rs
+++ b/core/src/mac/scsi/cdrom/mod.rs
@@ -111,9 +111,29 @@ pub struct SessionInfo {
     tracks: Vec<TrackInfo>,
 }
 
+pub enum CdromError {
+    /// SCSI read error with CC, ASC/ASCQ
+    CheckCondition(u8, u16),
+    /// Any other type of error
+    Other(anyhow::Error),
+}
+
+impl From<anyhow::Error> for CdromError {
+    fn from(value: anyhow::Error) -> Self {
+        Self::Other(value)
+    }
+}
+
 pub trait CdromBackend: Send {
     fn byte_len(&self) -> usize;
-    fn read_bytes(&self, offset: usize, length: usize) -> Result<Vec<u8>>;
+
+    /// The SCSI CD-ROM protocol allows reading blocks with standard READ commands.
+    ///
+    /// Each sector accessed by this method is expected to be a Mode 1 or Mode 2 Form 1
+    /// sector containing 2048 bytes of user data. If the wrong type of sector is accessed,
+    /// it fails with an ILLEGAL MODE FOR THIS TRACK error.
+    fn read_bytes(&self, offset: usize, length: usize) -> Result<Vec<u8>, CdromError>;
+
     fn image_path(&self) -> Option<&Path>;
 
     /// Return a list of sessions, each containing a list of tracks.
@@ -693,7 +713,15 @@ impl ScsiTarget for ScsiTargetCdrom {
                 result.resize(block_count * blocksize, 0);
                 Ok(result)
             }
-            Err(e) => {
+            Err(CdromError::CheckCondition(cc, asc)) => {
+                self.common.set_cc(cc, asc);
+                Err(anyhow!(
+                    "CD-ROM read error with cc {:02X}h, ASC {:04X}h",
+                    cc,
+                    asc
+                ))
+            }
+            Err(CdromError::Other(e)) => {
                 self.common
                     .set_cc(CC_KEY_MEDIUM_ERROR, ASC_UNRECOVERED_READ_ERROR);
                 Err(e)


### PR DESCRIPTION
This PR improves the correctness of reading CD-ROM data bytes:

- Fix reading at the wrong position when byte offset is not aligned to a block (this could happen on A/UX, which allegedly sets the blocksize to 512)
- Add more error detection

I'd like to get this in before the next release. This does not fix reading the Weird Al bonus content (tragically).