### PR TITLE
Support Enhanced CD's

### DIFF
--- a/core/src/mac/scsi/cdrom/backends/cuesheet.rs
+++ b/core/src/mac/scsi/cdrom/backends/cuesheet.rs
@@ -569,6 +569,9 @@ impl CdromBackend for CuesheetCdromBackend {
 
         let track = get_track_at_sector(&self.tracks, sector)
             .ok_or_else(|| anyhow!("No track found at sector {}", sector))?;
+        if sector >= self.sessions[track.session as usize - 1].leadout {
+            bail!("Sector {} was past the lead-out", sector);
+        }
 
         let data = match map_entry.source {
             SectorSource::Zeros => [0; RAW_SECTOR_LEN],

--- a/core/src/mac/scsi/cdrom/backends/cuesheet.rs
+++ b/core/src/mac/scsi/cdrom/backends/cuesheet.rs
@@ -106,7 +106,7 @@ enum SectorSource {
     DataFile {
         /// Index of file in the `files` array
         file_idx: usize,
-        /// Sector number relative to the beginning of the file
+        /// Byte offset within the file
         file_offset: u64,
         format: SectorSourceFormat,
     },
@@ -261,7 +261,14 @@ impl CuesheetCdromBackend {
         let mut source_format = SectorSourceFormat::Raw2352;
         let mut next_source_format = SectorSourceFormat::Raw2352;
         let mut gap_sectors = 0;
+        let mut session_has_tracks = false;
 
+        let mut sessions = vec![SessionInfo {
+            number: 1,
+            disc_type: 0x00,
+            leadin: 0,
+            leadout: LBA_START_SECTOR,
+        }];
         let mut tracks = vec![];
 
         // FIXME: I believe cue files have one command per line and never split commands across multiple lines. Is this true?
@@ -299,7 +306,11 @@ impl CuesheetCdromBackend {
                             .ok_or_else(|| anyhow!("Invalid TRACK command"))?;
                         (next_source_format, track_control) = match track_form_str.as_str() {
                             "AUDIO" => (SectorSourceFormat::Raw2352, AUDIO_TRACK),
-                            "MODE1/2352" | "MODE2/2352" => {
+                            "MODE1/2352" => (SectorSourceFormat::Raw2352, DATA_TRACK),
+                            "MODE2/2352" => {
+                                if !session_has_tracks {
+                                    sessions.last_mut().unwrap().disc_type = 0x20; // CD data XA disc with first track in Mode 2
+                                }
                                 (SectorSourceFormat::Raw2352, DATA_TRACK)
                             }
                             _ => bail!("Unsupported track form {}", track_form_str),
@@ -325,19 +336,73 @@ impl CuesheetCdromBackend {
                             // The track will officially begin at index 1.
                             tracks.push(TrackInfo {
                                 tno: track_num,
-                                session: 1,
+                                session: sessions.last().unwrap().number,
                                 control: track_control,
                                 sector: sector_map.abs_cursor,
                             });
                         }
+
+                        if !session_has_tracks {
+                            // Set the lead-in to 150 sectors before the first track
+                            // FIXME: lead-in might be set incorrectly if pregaps/postgaps are present...
+                            sessions.last_mut().unwrap().leadin =
+                                sector_map.abs_cursor.saturating_sub(LBA_START_SECTOR);
+                        }
+
+                        session_has_tracks = true;
                     }
                     "PREGAP" | "POSTGAP" => {
                         let duration = read_cue_msf(&mut chars)?.to_sector();
                         // Zeros sectors will be added to the map by the INDEX command
                         gap_sectors += duration;
                     }
-                    "REM" => (), // TODO: support REM LEAD-OUT and REM SESSION
-                    // TODO: Support multisession bin/cue's. IsoBuster emits REM SESSION commands to indicate a new session.
+                    "REM" => {
+                        if let Some(rem_cmd) = read_cue_word(&mut chars) {
+                            match rem_cmd.as_str() {
+                                "LEAD-OUT" => {
+                                    if let Ok(leadout_msf) = read_cue_msf(&mut chars) {
+                                        sector_map.add_file_up_to(
+                                            leadout_msf.to_sector(),
+                                            source_format,
+                                        )?;
+
+                                        sector_map.add_gap(gap_sectors);
+                                        gap_sectors = 0;
+
+                                        sessions.last_mut().unwrap().leadout =
+                                            sector_map.abs_cursor;
+                                    } else {
+                                        log::warn!("Failed to parse MSF in REM LEAD-OUT");
+                                    }
+                                }
+                                "SESSION" => {
+                                    if let Some(new_session) =
+                                        read_cue_word(&mut chars).and_then(|w| w.parse::<u8>().ok())
+                                    {
+                                        let last_session = sessions.last().unwrap();
+                                        if new_session == last_session.number + 1 {
+                                            sessions.push(SessionInfo {
+                                                number: new_session,
+                                                disc_type: 0x00,
+                                                leadin: last_session.leadout,
+                                                leadout: last_session.leadout,
+                                            });
+
+                                            session_has_tracks = false;
+                                        } else if !(new_session == 1 && sessions.len() == 1) {
+                                            log::warn!(
+                                                "Unexpected session number {} in REM SESSION command",
+                                                new_session
+                                            );
+                                        }
+                                    } else {
+                                        log::warn!("Unexpected token in REM SESSION command");
+                                    }
+                                }
+                                _ => (), // Just a regular REM comment; ignore
+                            }
+                        }
+                    }
                     _ => log::warn!("Unknown cuesheet command {} ignored", command),
                 }
             }
@@ -357,15 +422,16 @@ impl CuesheetCdromBackend {
             .map(|e| e.sector + e.sector_count)
             .unwrap_or(LBA_START_SECTOR);
 
+        if sessions.last().unwrap().leadout < final_leadout {
+            sessions.last_mut().unwrap().leadout = final_leadout;
+        }
+
+        log::debug!("Sessions: {:#?}", sessions);
+
         Ok(Self {
             cue_path: path.into(),
             files,
-            sessions: vec![SessionInfo {
-                number: 1,
-                disc_type: 0x00,
-                leadin: 0,
-                leadout: final_leadout,
-            }],
+            sessions,
             tracks,
             sector_map,
         })

--- a/core/src/mac/scsi/cdrom/backends/cuesheet.rs
+++ b/core/src/mac/scsi/cdrom/backends/cuesheet.rs
@@ -18,6 +18,7 @@ use crate::mac::scsi::{
 // .cue file reference:
 //
 // [LIBODRAW]: <https://github.com/libyal/libodraw/blob/main/documentation/CUE%20sheet%20format.asciidoc>
+// [LIBODRAW-RAW]: <https://github.com/libyal/libodraw/blob/main/documentation/Optical%20disc%20RAW%20format.asciidoc>
 
 fn skip_whitespace(reader: &mut Peekable<Chars>) {
     while reader.peek().map(|c| c.is_whitespace()).unwrap_or(false) {
@@ -90,6 +91,12 @@ struct CuesheetDataFile {
     file: File,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum SectorSourceFormat {
+    Raw2352,
+    // TODO: support 2048-byte formats
+}
+
 #[derive(Debug)]
 enum SectorSource {
     /// Sectors filled with zeroes. Used for pregaps and postgaps.
@@ -99,7 +106,9 @@ enum SectorSource {
         /// Index of file in the `files` array
         file_idx: usize,
         /// Sector number relative to the beginning of the file
+        /// TODO: change to byte offset
         file_sector: u32,
+        format: SectorSourceFormat,
     },
 }
 
@@ -140,7 +149,8 @@ impl SectorMapBuilder {
 
     fn start_new_file(&mut self, idx: usize, max: u32) -> Result<()> {
         // If a data file exists, add the rest of its sectors before starting the new file
-        self.add_rest_of_file()?;
+        // TODO: support formats other than Raw2352
+        self.add_rest_of_file(SectorSourceFormat::Raw2352)?;
         self.file_cursor = 0;
         self.file_idx = idx;
         self.file_max = max;
@@ -149,7 +159,7 @@ impl SectorMapBuilder {
     }
 
     /// Add data sectors up to a given sector number within the data file
-    fn add_file_up_to(&mut self, up_to: u32) -> Result<()> {
+    fn add_file_up_to(&mut self, up_to: u32, format: SectorSourceFormat) -> Result<()> {
         if up_to < self.file_cursor {
             bail!("File sector number cannot decrease");
         }
@@ -161,8 +171,13 @@ impl SectorMapBuilder {
         let additional = up_to - self.file_cursor;
 
         if let Some(entry) = self.map.last_mut()
-            && let SectorSource::DataFile { file_idx, .. } = entry.source
+            && let SectorSource::DataFile {
+                file_idx,
+                format: last_format,
+                ..
+            } = entry.source
             && file_idx == self.file_idx
+            && last_format == format
         {
             // Add more sectors to the existing map entry
             entry.sector_count += additional;
@@ -174,6 +189,7 @@ impl SectorMapBuilder {
                 source: SectorSource::DataFile {
                     file_idx: self.file_idx,
                     file_sector: self.file_cursor,
+                    format,
                 },
             });
         }
@@ -203,12 +219,12 @@ impl SectorMapBuilder {
         self.abs_cursor += sectors;
     }
 
-    fn add_rest_of_file(&mut self) -> Result<()> {
-        self.add_file_up_to(self.file_max)
+    fn add_rest_of_file(&mut self, format: SectorSourceFormat) -> Result<()> {
+        self.add_file_up_to(self.file_max, format)
     }
 
-    fn build(mut self) -> Result<Vec<SectorMapEntry>> {
-        self.add_rest_of_file()?;
+    fn build(self) -> Result<Vec<SectorMapEntry>> {
+        // self.add_rest_of_file()?;
         Ok(self.map)
     }
 }
@@ -223,11 +239,6 @@ pub struct CuesheetCdromBackend {
     sector_map: Vec<SectorMapEntry>,
 }
 
-enum CuesheetTrackForm {
-    Audio,
-    Mode1_2352,
-}
-
 impl CuesheetCdromBackend {
     pub fn new(path: &Path) -> Result<Self> {
         let cue_dir = path.parent().unwrap();
@@ -237,7 +248,8 @@ impl CuesheetCdromBackend {
         let mut sector_map = SectorMapBuilder::new();
 
         let mut track_num = 0u8;
-        let mut track_form = CuesheetTrackForm::Audio;
+        let mut track_control = DATA_TRACK;
+        let mut source_format = SectorSourceFormat::Raw2352;
         let mut gap_sectors = 0;
 
         let mut tracks = vec![];
@@ -274,13 +286,14 @@ impl CuesheetCdromBackend {
                         track_num = read_cue_word(&mut chars)
                             .ok_or_else(|| anyhow!("Invalid TRACK command"))?
                             .parse()?;
-                        track_form = match read_cue_word(&mut chars)
-                            .ok_or_else(|| anyhow!("Invalid TRACK command"))?
-                            .as_str()
-                        {
-                            "AUDIO" => CuesheetTrackForm::Audio,
-                            "MODE1/2352" => CuesheetTrackForm::Mode1_2352,
-                            _ => bail!("Unsupported track form"),
+                        let track_form_str = read_cue_word(&mut chars)
+                            .ok_or_else(|| anyhow!("Invalid TRACK command"))?;
+                        (source_format, track_control) = match track_form_str.as_str() {
+                            "AUDIO" => (SectorSourceFormat::Raw2352, AUDIO_TRACK),
+                            "MODE1/2352" | "MODE2/2352" => {
+                                (SectorSourceFormat::Raw2352, DATA_TRACK)
+                            }
+                            _ => bail!("Unsupported track form {}", track_form_str),
                         };
                     }
                     "INDEX" => {
@@ -292,7 +305,7 @@ impl CuesheetCdromBackend {
                         let file_sector = read_cue_msf(&mut chars)?.to_sector();
 
                         // Add any previous file data up to this point
-                        sector_map.add_file_up_to(file_sector)?;
+                        sector_map.add_file_up_to(file_sector, source_format)?;
 
                         // Add pregaps/postgaps here
                         sector_map.add_gap(gap_sectors);
@@ -302,10 +315,7 @@ impl CuesheetCdromBackend {
                             // The track will officially begin at index 1.
                             tracks.push(TrackInfo {
                                 tno: track_num,
-                                control: match track_form {
-                                    CuesheetTrackForm::Audio => AUDIO_TRACK,
-                                    CuesheetTrackForm::Mode1_2352 => DATA_TRACK,
-                                },
+                                control: track_control,
                                 sector: sector_map.abs_cursor,
                             });
                         }
@@ -324,7 +334,7 @@ impl CuesheetCdromBackend {
         log::debug!("Tracks: {:#?}", tracks);
 
         // In case the final track has a postgap...
-        sector_map.add_rest_of_file()?;
+        sector_map.add_rest_of_file(source_format)?;
         sector_map.add_gap(gap_sectors);
 
         let sector_map = sector_map.build()?;
@@ -347,19 +357,29 @@ impl CuesheetCdromBackend {
     }
 
     fn find_map_entry_for_sector(&self, sector: u32) -> Option<&SectorMapEntry> {
-        // TODO: use partition_point?
-        let idx = self
-            .sector_map
-            .iter()
-            .rposition(|entry| sector >= entry.sector)?;
-        self.sector_map.get(idx)
+        let idx = match self.sector_map.binary_search_by(|e| e.sector.cmp(&sector)) {
+            Ok(idx) => idx,
+            Err(idx) => idx.saturating_sub(1),
+        };
+        self.sector_map
+            .get(idx)
+            .filter(|e| (e.sector..e.sector + e.sector_count).contains(&sector))
     }
 }
 
 impl CdromBackend for CuesheetCdromBackend {
     fn byte_len(&self) -> usize {
-        // FIXME: What's the correct value here? Let's just say 333,000 * 2048-byte sectors.
-        333_000 * 2048
+        // To find the capacity, treat each sector (except the lead-in) as a block
+        // containing 2048 bytes.
+        // However, only sectors in a Data track in Mode 1 or Mode 2 Form 1 are readable
+        // via `read_bytes`.
+        let final_leadout = self
+            .sector_map
+            .last()
+            .map(|e| e.sector + e.sector_count)
+            .unwrap_or(LBA_START_SECTOR);
+        let final_lba = final_leadout.saturating_sub(LBA_START_SECTOR);
+        usize::try_from(final_lba).unwrap() * 2048
     }
 
     fn read_bytes(&self, offset: usize, length: usize) -> Result<Vec<u8>, CdromError> {
@@ -377,7 +397,8 @@ impl CdromBackend for CuesheetCdromBackend {
             let raw_sector = self.read_raw_sector(sector)?;
 
             // Check sync field
-            if raw_sector[0..12] != *b"\x00\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x00" {
+            let sync = &raw_sector[0..12];
+            if sync != *b"\x00\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\x00" {
                 log::warn!("Failed to read sector {}: invalid sync field", sector);
                 return Err(CdromError::CheckCondition(
                     CC_KEY_MEDIUM_ERROR,
@@ -386,21 +407,50 @@ impl CdromBackend for CuesheetCdromBackend {
             }
 
             // Check mode field
-            // TODO: support Mode 2 Form 1 sectors
-            if raw_sector[15] != 1 {
-                log::warn!(
-                    "Failed to read sector {}: unexpected mode field {}",
-                    sector,
-                    raw_sector[15]
-                );
-                return Err(CdromError::CheckCondition(
-                    CC_KEY_MEDIUM_ERROR,
-                    ASC_UNRECOVERED_READ_ERROR,
-                ));
-            }
+            let mode = raw_sector[15];
+            let user_data = match mode {
+                // TODO: check error detection codes?
+                1 => &raw_sector[16..][..2048],
+                2 => {
+                    let subheader = &raw_sector[16..20];
+                    if *subheader != raw_sector[20..24] {
+                        log::warn!(
+                            "Failed to read sector {}: Mode 2 subheader mismatch",
+                            sector
+                        );
+                        return Err(CdromError::CheckCondition(
+                            CC_KEY_MEDIUM_ERROR,
+                            ASC_UNRECOVERED_READ_ERROR,
+                        ));
+                    }
 
-            // TODO: Check error detection codes?
-            let user_data = &raw_sector[16..][..2048];
+                    if subheader[2] & (1 << 5) != 0 {
+                        log::warn!(
+                            "Failed to read sector {}: Cannot read Mode 2 Form 2",
+                            sector
+                        );
+                        return Err(CdromError::CheckCondition(
+                            CC_KEY_MEDIUM_ERROR,
+                            ASC_UNRECOVERED_READ_ERROR,
+                        ));
+                    }
+
+                    // TODO: check error detection codes?
+                    &raw_sector[24..][..2048]
+                }
+                _ => {
+                    log::warn!(
+                        "Failed to read sector {}: Unexpected mode field {}",
+                        sector,
+                        mode
+                    );
+                    return Err(CdromError::CheckCondition(
+                        CC_KEY_MEDIUM_ERROR,
+                        ASC_UNRECOVERED_READ_ERROR,
+                    ));
+                }
+            };
+
             result.extend_from_slice(&user_data[data_offset..]);
 
             sector += 1;
@@ -434,6 +484,7 @@ impl CdromBackend for CuesheetCdromBackend {
             SectorSource::DataFile {
                 file_idx,
                 file_sector,
+                ..
             } => {
                 let file = &self.files[file_idx];
                 let sector_in_file = file_sector + rel_sector;

--- a/core/src/mac/scsi/cdrom/backends/cuesheet.rs
+++ b/core/src/mac/scsi/cdrom/backends/cuesheet.rs
@@ -8,10 +8,11 @@ use std::{
 };
 
 use crate::mac::scsi::{
-    ASC_UNRECOVERED_READ_ERROR, CC_KEY_MEDIUM_ERROR,
+    ASC_ILLEGAL_MODE_FOR_THIS_TRACK, ASC_UNRECOVERED_READ_ERROR, CC_KEY_ILLEGAL_REQUEST,
+    CC_KEY_MEDIUM_ERROR,
     cdrom::{
         AUDIO_TRACK, CdromBackend, CdromError, DATA_TRACK, LBA_START_SECTOR, Msf, RAW_SECTOR_LEN,
-        SessionInfo, TrackInfo,
+        RawSector, SessionInfo, TrackInfo, get_track_at_sector,
     },
 };
 
@@ -470,9 +471,17 @@ impl CdromBackend for CuesheetCdromBackend {
             LBA_START_SECTOR + u32::try_from(offset / 2048).map_err(|e| anyhow!(e))?;
         let mut data_offset = offset % 2048;
         while result.len() < length {
-            // FIXME: read_raw_sector should return the track form (audio or data); this method
-            // should fail with ILLEGAL_MODE_FOR_THIS_TRACK if this isn't a data sector.
             let raw_sector = self.read_raw_sector(sector)?;
+
+            if raw_sector.control != DATA_TRACK {
+                log::warn!("Tried to read bytes from non-data sector {}", sector);
+                return Err(CdromError::CheckCondition(
+                    CC_KEY_ILLEGAL_REQUEST,
+                    ASC_ILLEGAL_MODE_FOR_THIS_TRACK,
+                ));
+            }
+
+            let raw_sector = raw_sector.data;
 
             // Check sync field
             let sync = &raw_sector[0..12];
@@ -551,14 +560,17 @@ impl CdromBackend for CuesheetCdromBackend {
         Some(&self.tracks)
     }
 
-    fn read_raw_sector(&self, sector: u32) -> Result<[u8; RAW_SECTOR_LEN]> {
+    fn read_raw_sector(&self, sector: u32) -> Result<RawSector> {
         let map_entry = self
             .find_map_entry_for_sector(sector)
             .ok_or_else(|| anyhow!("Sector {} not found in sector map", sector))?;
 
         let rel_sector = sector - map_entry.sector;
 
-        let result = match map_entry.source {
+        let track = get_track_at_sector(&self.tracks, sector)
+            .ok_or_else(|| anyhow!("No track found at sector {}", sector))?;
+
+        let data = match map_entry.source {
             SectorSource::Zeros => [0; RAW_SECTOR_LEN],
             SectorSource::DataFile {
                 file_idx,
@@ -583,6 +595,9 @@ impl CdromBackend for CuesheetCdromBackend {
             }
         };
 
-        Ok(result)
+        Ok(RawSector {
+            data,
+            control: track.control,
+        })
     }
 }

--- a/core/src/mac/scsi/cdrom/backends/cuesheet.rs
+++ b/core/src/mac/scsi/cdrom/backends/cuesheet.rs
@@ -84,17 +84,18 @@ fn read_cue_msf(reader: &mut Peekable<Chars>) -> Result<Msf> {
     Ok(Msf::new(m, s, f))
 }
 
-struct CuesheetDataFile {
-    /// Number of sectors in data file (not counting pregaps and postgaps)
-    #[allow(unused)]
-    sector_count: u32,
-    file: File,
-}
-
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum SectorSourceFormat {
     Raw2352,
     // TODO: support 2048-byte formats
+}
+
+impl SectorSourceFormat {
+    fn bytes_per_sector(self) -> u64 {
+        match self {
+            Self::Raw2352 => 2352,
+        }
+    }
 }
 
 #[derive(Debug)]
@@ -106,8 +107,7 @@ enum SectorSource {
         /// Index of file in the `files` array
         file_idx: usize,
         /// Sector number relative to the beginning of the file
-        /// TODO: change to byte offset
-        file_sector: u32,
+        file_offset: u64,
         format: SectorSourceFormat,
     },
 }
@@ -122,12 +122,16 @@ struct SectorMapEntry {
 struct SectorMapBuilder {
     /// Absolute sector number
     abs_cursor: u32,
+    /// Byte offset within current data file
+    file_offset: u64,
+    /// Max bytes in current data file
+    file_size: u64,
     /// Sector number within current data file
-    file_cursor: u32,
-    /// Max sectors in current data file
-    file_max: u32,
+    file_sector: u32,
     /// Index of current data file in the cuesheet's `files` array
     file_idx: usize,
+    /// Most recent source format
+    last_format: SectorSourceFormat,
     map: Vec<SectorMapEntry>,
 }
 
@@ -140,35 +144,34 @@ impl SectorMapBuilder {
         // data such as CD-TEXT information.
         Self {
             abs_cursor: LBA_START_SECTOR,
-            file_cursor: 0,
-            file_max: 0,
+            file_offset: 0,
+            file_size: 0,
+            file_sector: 0,
             file_idx: 0,
+            last_format: SectorSourceFormat::Raw2352,
             map: vec![],
         }
     }
 
-    fn start_new_file(&mut self, idx: usize, max: u32) -> Result<()> {
+    fn start_new_file(&mut self, idx: usize, size: u64) -> Result<()> {
         // If a data file exists, add the rest of its sectors before starting the new file
         // TODO: support formats other than Raw2352
-        self.add_rest_of_file(SectorSourceFormat::Raw2352)?;
-        self.file_cursor = 0;
+        self.add_rest_of_file()?;
+        self.file_offset = 0;
+        self.file_size = size;
+        self.file_sector = 0;
         self.file_idx = idx;
-        self.file_max = max;
 
         Ok(())
     }
 
     /// Add data sectors up to a given sector number within the data file
     fn add_file_up_to(&mut self, up_to: u32, format: SectorSourceFormat) -> Result<()> {
-        if up_to < self.file_cursor {
+        if up_to < self.file_sector {
             bail!("File sector number cannot decrease");
         }
 
-        if up_to > self.file_max {
-            bail!("File sector number exceeded max");
-        }
-
-        let additional = up_to - self.file_cursor;
+        let additional_sectors = up_to - self.file_sector;
 
         if let Some(entry) = self.map.last_mut()
             && let SectorSource::DataFile {
@@ -180,22 +183,24 @@ impl SectorMapBuilder {
             && last_format == format
         {
             // Add more sectors to the existing map entry
-            entry.sector_count += additional;
-        } else if additional > 0 {
+            entry.sector_count += additional_sectors;
+        } else if additional_sectors > 0 {
             // Start a new map entry
             self.map.push(SectorMapEntry {
                 sector: self.abs_cursor,
-                sector_count: additional,
+                sector_count: additional_sectors,
                 source: SectorSource::DataFile {
                     file_idx: self.file_idx,
-                    file_sector: self.file_cursor,
+                    file_offset: self.file_offset,
                     format,
                 },
             });
         }
 
-        self.file_cursor += additional;
-        self.abs_cursor += additional;
+        self.file_sector += additional_sectors;
+        self.file_offset += additional_sectors as u64 * format.bytes_per_sector();
+        self.abs_cursor += additional_sectors;
+        self.last_format = format;
 
         Ok(())
     }
@@ -219,19 +224,22 @@ impl SectorMapBuilder {
         self.abs_cursor += sectors;
     }
 
-    fn add_rest_of_file(&mut self, format: SectorSourceFormat) -> Result<()> {
-        self.add_file_up_to(self.file_max, format)
+    fn add_rest_of_file(&mut self) -> Result<()> {
+        let remaining_bytes = self.file_size - self.file_offset;
+        let remaining_sectors: u32 =
+            (remaining_bytes / self.last_format.bytes_per_sector()).try_into()?;
+        self.add_file_up_to(self.file_sector + remaining_sectors, self.last_format)
     }
 
-    fn build(self) -> Result<Vec<SectorMapEntry>> {
-        // self.add_rest_of_file()?;
+    fn build(mut self) -> Result<Vec<SectorMapEntry>> {
+        self.add_rest_of_file()?;
         Ok(self.map)
     }
 }
 
 pub struct CuesheetCdromBackend {
     cue_path: PathBuf,
-    files: Vec<CuesheetDataFile>,
+    files: Vec<File>,
     sessions: Vec<SessionInfo>,
     /// Map of sectors. Entries are sorted in order of increasing `sector` field.
     /// This table maps absolute sector numbers to data files. This is NOT the
@@ -244,12 +252,13 @@ impl CuesheetCdromBackend {
         let cue_dir = path.parent().unwrap();
         let cue_file = BufReader::new(File::open(path)?);
 
-        let mut files: Vec<CuesheetDataFile> = vec![];
+        let mut files: Vec<File> = vec![];
         let mut sector_map = SectorMapBuilder::new();
 
         let mut track_num = 0u8;
         let mut track_control = DATA_TRACK;
         let mut source_format = SectorSourceFormat::Raw2352;
+        let mut next_source_format = SectorSourceFormat::Raw2352;
         let mut gap_sectors = 0;
 
         let mut tracks = vec![];
@@ -277,10 +286,9 @@ impl CuesheetCdromBackend {
 
                         let file = File::open(file_path)?;
                         let file_len = file.metadata()?.len();
-                        let sector_count = file_len.div_ceil(RAW_SECTOR_LEN as u64).try_into()?;
-                        files.push(CuesheetDataFile { sector_count, file });
+                        files.push(file);
 
-                        sector_map.start_new_file(files.len() - 1, sector_count)?;
+                        sector_map.start_new_file(files.len() - 1, file_len)?;
                     }
                     "TRACK" => {
                         track_num = read_cue_word(&mut chars)
@@ -288,7 +296,7 @@ impl CuesheetCdromBackend {
                             .parse()?;
                         let track_form_str = read_cue_word(&mut chars)
                             .ok_or_else(|| anyhow!("Invalid TRACK command"))?;
-                        (source_format, track_control) = match track_form_str.as_str() {
+                        (next_source_format, track_control) = match track_form_str.as_str() {
                             "AUDIO" => (SectorSourceFormat::Raw2352, AUDIO_TRACK),
                             "MODE1/2352" | "MODE2/2352" => {
                                 (SectorSourceFormat::Raw2352, DATA_TRACK)
@@ -306,6 +314,7 @@ impl CuesheetCdromBackend {
 
                         // Add any previous file data up to this point
                         sector_map.add_file_up_to(file_sector, source_format)?;
+                        source_format = next_source_format;
 
                         // Add pregaps/postgaps here
                         sector_map.add_gap(gap_sectors);
@@ -325,6 +334,7 @@ impl CuesheetCdromBackend {
                         // Zeros sectors will be added to the map by the INDEX command
                         gap_sectors += duration;
                     }
+                    "REM" => (), // TODO: support REM LEAD-OUT and REM SESSION
                     // TODO: Support multisession bin/cue's. IsoBuster emits REM SESSION commands to indicate a new session.
                     _ => log::warn!("Unknown cuesheet command {} ignored", command),
                 }
@@ -334,7 +344,7 @@ impl CuesheetCdromBackend {
         log::debug!("Tracks: {:#?}", tracks);
 
         // In case the final track has a postgap...
-        sector_map.add_rest_of_file(source_format)?;
+        sector_map.add_rest_of_file()?;
         sector_map.add_gap(gap_sectors);
 
         let sector_map = sector_map.build()?;
@@ -385,9 +395,6 @@ impl CdromBackend for CuesheetCdromBackend {
     fn read_bytes(&self, offset: usize, length: usize) -> Result<Vec<u8>, CdromError> {
         let mut result = Vec::<u8>::with_capacity(length);
 
-        // TODO: uh-oh, do we need to support CD-ROM's where the data is in session 2?
-        // Example: "Weird Al" Yankovic - Running With Scissors
-        // (the Weird Al disc also uses Mode 2 sectors in its data track!)
         let mut sector: u32 =
             LBA_START_SECTOR + u32::try_from(offset / 2048).map_err(|e| anyhow!(e))?;
         let mut data_offset = offset % 2048;
@@ -473,9 +480,6 @@ impl CdromBackend for CuesheetCdromBackend {
         let map_entry = self
             .find_map_entry_for_sector(sector)
             .ok_or_else(|| anyhow!("Sector {} not found in sector map", sector))?;
-        if !(map_entry.sector..map_entry.sector + map_entry.sector_count).contains(&sector) {
-            bail!("Sector {} not found in sector map", sector);
-        }
 
         let rel_sector = sector - map_entry.sector;
 
@@ -483,21 +487,24 @@ impl CdromBackend for CuesheetCdromBackend {
             SectorSource::Zeros => [0; RAW_SECTOR_LEN],
             SectorSource::DataFile {
                 file_idx,
-                file_sector,
-                ..
+                file_offset,
+                format,
             } => {
-                let file = &self.files[file_idx];
-                let sector_in_file = file_sector + rel_sector;
                 // It turns out you don't need a &mut File to seek and read!
                 // Just call seek and read on a `&File`. This will clobber the file cursor,
                 // so use with caution.
-                let mut file: &File = &file.file;
+                let mut file: &File = &self.files[file_idx];
                 file.seek(SeekFrom::Start(
-                    sector_in_file as u64 * RAW_SECTOR_LEN as u64,
+                    file_offset + rel_sector as u64 * format.bytes_per_sector(),
                 ))?;
-                let mut result = [0; RAW_SECTOR_LEN];
-                file.read_exact(&mut result)?;
-                result
+
+                match format {
+                    SectorSourceFormat::Raw2352 => {
+                        let mut result = [0u8; RAW_SECTOR_LEN];
+                        file.read_exact(&mut result)?;
+                        result
+                    }
+                }
             }
         };
 

--- a/core/src/mac/scsi/cdrom/backends/cuesheet.rs
+++ b/core/src/mac/scsi/cdrom/backends/cuesheet.rs
@@ -241,6 +241,7 @@ pub struct CuesheetCdromBackend {
     cue_path: PathBuf,
     files: Vec<File>,
     sessions: Vec<SessionInfo>,
+    tracks: Vec<TrackInfo>,
     /// Map of sectors. Entries are sorted in order of increasing `sector` field.
     /// This table maps absolute sector numbers to data files. This is NOT the
     /// table of contents; it doesn't carry information about tracks.
@@ -324,6 +325,7 @@ impl CuesheetCdromBackend {
                             // The track will officially begin at index 1.
                             tracks.push(TrackInfo {
                                 tno: track_num,
+                                session: 1,
                                 control: track_control,
                                 sector: sector_map.abs_cursor,
                             });
@@ -359,9 +361,12 @@ impl CuesheetCdromBackend {
             cue_path: path.into(),
             files,
             sessions: vec![SessionInfo {
+                number: 1,
+                disc_type: 0x00,
+                leadin: 0,
                 leadout: final_leadout,
-                tracks,
             }],
+            tracks,
             sector_map,
         })
     }
@@ -474,6 +479,10 @@ impl CdromBackend for CuesheetCdromBackend {
 
     fn sessions(&self) -> Option<&[SessionInfo]> {
         Some(&self.sessions)
+    }
+
+    fn tracks(&self) -> Option<&[TrackInfo]> {
+        Some(&self.tracks)
     }
 
     fn read_raw_sector(&self, sector: u32) -> Result<[u8; RAW_SECTOR_LEN]> {

--- a/core/src/mac/scsi/cdrom/backends/iso.rs
+++ b/core/src/mac/scsi/cdrom/backends/iso.rs
@@ -12,6 +12,7 @@ use crate::mac::scsi::{
 pub struct IsoCdromBackend {
     image: Box<dyn DiskImage>,
     session: SessionInfo,
+    track: TrackInfo,
 }
 
 impl IsoCdromBackend {
@@ -20,12 +21,16 @@ impl IsoCdromBackend {
         Ok(Self {
             image,
             session: SessionInfo {
+                number: 1,
+                disc_type: 0x00,
+                leadin: 0,
                 leadout: LBA_START_SECTOR + sector_count,
-                tracks: vec![TrackInfo {
-                    tno: 1,
-                    control: DATA_TRACK,
-                    sector: LBA_START_SECTOR,
-                }],
+            },
+            track: TrackInfo {
+                tno: 1,
+                session: 1,
+                control: DATA_TRACK,
+                sector: LBA_START_SECTOR,
             },
         })
     }
@@ -46,6 +51,10 @@ impl CdromBackend for IsoCdromBackend {
 
     fn sessions(&self) -> Option<&[SessionInfo]> {
         Some(std::slice::from_ref(&self.session))
+    }
+
+    fn tracks(&self) -> Option<&[TrackInfo]> {
+        Some(std::slice::from_ref(&self.track))
     }
 
     fn read_raw_sector(&self, _sector: u32) -> Result<[u8; RAW_SECTOR_LEN]> {

--- a/core/src/mac/scsi/cdrom/backends/iso.rs
+++ b/core/src/mac/scsi/cdrom/backends/iso.rs
@@ -3,8 +3,7 @@ use std::path::Path;
 
 use crate::mac::scsi::{
     cdrom::{
-        CdromBackend, CdromError, DATA_TRACK, LBA_START_SECTOR, RAW_SECTOR_LEN, SessionInfo,
-        TrackInfo,
+        CdromBackend, CdromError, DATA_TRACK, LBA_START_SECTOR, RawSector, SessionInfo, TrackInfo,
     },
     disk_image::DiskImage,
 };
@@ -57,7 +56,7 @@ impl CdromBackend for IsoCdromBackend {
         Some(std::slice::from_ref(&self.track))
     }
 
-    fn read_raw_sector(&self, _sector: u32) -> Result<[u8; RAW_SECTOR_LEN]> {
+    fn read_raw_sector(&self, _sector: u32) -> Result<RawSector> {
         // TODO: reconstruct raw sectors from ISO data
         // (probably only needed for some disc ripping software to work)
         bail!("Reading raw sectors is not implemented for ISO files");

--- a/core/src/mac/scsi/cdrom/mod.rs
+++ b/core/src/mac/scsi/cdrom/mod.rs
@@ -115,6 +115,7 @@ pub struct TrackInfo {
     sector: u32, // Forget about MSF/LBA; use absolute sector numbers wherever possible.
 }
 
+#[derive(Debug)]
 pub struct SessionInfo {
     /// Session number. Always starts at 1.
     number: u8,
@@ -334,6 +335,8 @@ impl ScsiTargetCdrom {
                 let data_length = result.len() - 2;
                 result[0..2].copy_from_slice(&u16::to_be_bytes(data_length.try_into()?));
 
+                log::debug!("formatted toc bytes: {:?}", result);
+
                 result.truncate(alloc_len);
                 Ok(ScsiCmdResult::DataIn(result))
             }
@@ -353,7 +356,7 @@ impl ScsiTargetCdrom {
                 let first_track_of_last_session = tracks
                     .iter()
                     .find(|t| t.session >= last_session_no)
-                    .unwrap();
+                    .ok_or_else(|| anyhow!("No tracks in last session"))?;
 
                 // [PIONEER] Table 2-28D: Track Descriptors
                 result.push(0); // Reserved
@@ -367,6 +370,8 @@ impl ScsiTargetCdrom {
 
                 let data_length = result.len() - 2;
                 result[0..2].copy_from_slice(&u16::to_be_bytes(data_length.try_into()?));
+
+                log::debug!("session toc bytes: {:?}", result);
 
                 result.truncate(alloc_len);
                 Ok(ScsiCmdResult::DataIn(result))
@@ -490,6 +495,8 @@ impl ScsiTargetCdrom {
 
                 let data_length = result.len() - 2;
                 result[0..2].copy_from_slice(&u16::to_be_bytes(data_length.try_into()?));
+
+                log::debug!("full toc bytes: {:?}", result);
 
                 result.truncate(alloc_len);
                 Ok(ScsiCmdResult::DataIn(result))

--- a/core/src/mac/scsi/cdrom/mod.rs
+++ b/core/src/mac/scsi/cdrom/mod.rs
@@ -420,11 +420,13 @@ impl ScsiTargetCdrom {
                             result.push(0); // TNO (0 for the lead-in area)
                             result.push(0xB0); // POINT (Start time of next possible program)
                             result.extend_from_slice(
+                                // FIXME: It's unclear whether this should be BCD or binary.
+                                // It probably makes no difference.
                                 &Msf::from_sector(next_session.leadin)?.to_bytes(),
                             ); // Start time of next possible program
                             result.push(2); // # of pointers in Mode 5
                             result.extend_from_slice(
-                                &Msf::from_sector(sessions.last().unwrap().leadout)?.to_bytes(),
+                                &Msf::from_sector(sessions.last().unwrap().leadout)?.to_bcd_bytes(),
                             ); // Maximum start time of outer-most Lead-out area
 
                             // Start time of the first Lead-in Area of the disc
@@ -438,7 +440,7 @@ impl ScsiTargetCdrom {
                             result.push(0); // Zero
                             // FIXME: Weird Al actually puts 95:00:00 here? where does that come from?
                             result.extend_from_slice(
-                                &Msf::from_sector(sessions.first().unwrap().leadin)?.to_bytes(),
+                                &Msf::from_sector(sessions.first().unwrap().leadin)?.to_bcd_bytes(),
                             ); // Start time of the first Lead-in Area of the disc)
                         }
 
@@ -454,8 +456,8 @@ impl ScsiTargetCdrom {
                         result.push(0);
                         result.push(0);
                         result.push(0); // Zero
-                        result.push(track.tno); // First Track Number
-                        result.push(session.disc_type); // Disc Type
+                        result.push(bin_to_bcd(track.tno)); // First Track Number
+                        result.push(bin_to_bcd(session.disc_type)); // Disc Type
                         result.push(0);
 
                         // Last track number in the program area
@@ -472,7 +474,7 @@ impl ScsiTargetCdrom {
                             .rev()
                             .find(|t| t.session == session_no)
                             .unwrap();
-                        result.push(last_track_in_session.tno); // Last Track Number
+                        result.push(bin_to_bcd(last_track_in_session.tno)); // Last Track Number
                         result.push(0);
                         result.push(0);
 
@@ -486,7 +488,7 @@ impl ScsiTargetCdrom {
                         result.push(0);
                         result.push(0); // Zero
                         let leadout = Msf::from_sector(get_session(session_no).unwrap().leadout)?;
-                        result.extend_from_slice(&leadout.to_bytes()); // Start position of Lead-out
+                        result.extend_from_slice(&leadout.to_bcd_bytes()); // Start position of Lead-out
                     }
 
                     result.push(track.session); // Session Number
@@ -497,17 +499,13 @@ impl ScsiTargetCdrom {
                     result.push(0);
                     result.push(0);
                     result.push(0); // Zero
-                    // XXX: In order for Enhanced CD bonus content to work, we need to report timecodes
-                    // as BCD. But that breaks Battle Chess. Let's work around it here.
-                    // This is just enough BCD to allow Mac OS to find the bonus content.
-                    if track.control == DATA_TRACK
-                        && track.session != 1
-                        && get_session(track.session).unwrap().disc_type == 0x20
-                    {
-                        result.extend_from_slice(&Msf::from_sector(track.sector)?.to_bcd_bytes()); // Start position of track
-                    } else {
-                        result.extend_from_slice(&Msf::from_sector(track.sector)?.to_bytes()); // Start position of track
-                    }
+                    // [MMC4] 6.40.3.4.1:
+                    // Entries in bytes 2 through 7 of the descriptors (TNO, POINT, MIN, SEC, FRAME, ZERO) shall be
+                    // converted to binary by the Logical Unit when the media contains a value between 0 and 99bcd.
+                    // [...] Otherwise, the value is returned with no modification.
+                    // Note that this does NOT include the PMIN/PSEC/PFRAME fields! Meaning, these fields must
+                    // be represented in binary-coded decimal.
+                    result.extend_from_slice(&Msf::from_sector(track.sector)?.to_bcd_bytes()); // Start position of track
                 }
 
                 let data_length = result.len() - 2;

--- a/core/src/mac/scsi/cdrom/mod.rs
+++ b/core/src/mac/scsi/cdrom/mod.rs
@@ -63,6 +63,10 @@ const LBA_START_SECTOR: u32 = LBA_START_MSF.to_sector();
 /// Number of sectors per second of audio
 const AUDIO_SECTORS_PER_SEC: u32 = 75;
 
+fn bin_to_bcd(bin: u8) -> u8 {
+    ((bin / 10) << 4) | (bin % 10)
+}
+
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 struct Msf {
     m: u8,
@@ -81,6 +85,10 @@ impl Msf {
 
     fn to_bytes(self) -> [u8; 3] {
         [self.m, self.s, self.f]
+    }
+
+    fn to_bcd_bytes(self) -> [u8; 3] {
+        [self.m, self.s, self.f].map(bin_to_bcd)
     }
 
     fn from_sector(mut sector: u32) -> Result<Self> {
@@ -342,8 +350,6 @@ impl ScsiTargetCdrom {
                 let data_length = result.len() - 2;
                 result[0..2].copy_from_slice(&u16::to_be_bytes(data_length.try_into()?));
 
-                log::debug!("formatted toc bytes: {:?}", result);
-
                 result.truncate(alloc_len);
                 Ok(ScsiCmdResult::DataIn(result))
             }
@@ -378,8 +384,6 @@ impl ScsiTargetCdrom {
                 let data_length = result.len() - 2;
                 result[0..2].copy_from_slice(&u16::to_be_bytes(data_length.try_into()?));
 
-                log::debug!("session toc bytes: {:?}", result);
-
                 result.truncate(alloc_len);
                 Ok(ScsiCmdResult::DataIn(result))
             }
@@ -411,10 +415,6 @@ impl ScsiTargetCdrom {
 
                             // Start time of next possible program
                             let next_session = get_session(session_no + 1).unwrap();
-                            log::debug!(
-                                "emitting next session descriptor leadin {}",
-                                next_session.leadin
-                            );
                             result.push(session_no); // Session Number
                             result.push(5 << 4); // ADR; Control
                             result.push(0); // TNO (0 for the lead-in area)
@@ -497,13 +497,21 @@ impl ScsiTargetCdrom {
                     result.push(0);
                     result.push(0);
                     result.push(0); // Zero
-                    result.extend_from_slice(&Msf::from_sector(track.sector)?.to_bytes()); // Start position of track
+                    // XXX: In order for Enhanced CD bonus content to work, we need to report timecodes
+                    // as BCD. But that breaks Battle Chess. Let's work around it here.
+                    // This is just enough BCD to allow Mac OS to find the bonus content.
+                    if track.control == DATA_TRACK
+                        && track.session != 1
+                        && get_session(track.session).unwrap().disc_type == 0x20
+                    {
+                        result.extend_from_slice(&Msf::from_sector(track.sector)?.to_bcd_bytes()); // Start position of track
+                    } else {
+                        result.extend_from_slice(&Msf::from_sector(track.sector)?.to_bytes()); // Start position of track
+                    }
                 }
 
                 let data_length = result.len() - 2;
                 result[0..2].copy_from_slice(&u16::to_be_bytes(data_length.try_into()?));
-
-                log::debug!("full toc bytes: {:?}", result);
 
                 result.truncate(alloc_len);
                 Ok(ScsiCmdResult::DataIn(result))
@@ -1055,12 +1063,6 @@ impl ScsiTarget for ScsiTargetCdrom {
                     return Ok(ScsiCmdResult::Status(STATUS_CHECK_CONDITION));
                 };
 
-                // [PIONEER]: 2.13:
-                // If the starting address is not found, or if the address is not within an audio track, or if a not ready
-                // condition exists, the drive will terminate with a Check Condition status.
-                let session = &sessions[0];
-                // TODO: support multisession discs
-
                 // [MMC4] 6.17.2.3:
                 // If the Starting Minutes, Seconds, and Frame Fields are set to FFh, the Starting address is taken from
                 // the Current Optical Head location. This allows the Audio Ending address to be changed without
@@ -1077,12 +1079,19 @@ impl ScsiTarget for ScsiTargetCdrom {
                     // If the starting MSF address is greater than the ending MSF
                     // address, the command shall be terminated with CHECK CONDITION status and SK/ASC/ASCQ
                     // values shall be set to ILLEGAL REQUEST/INVALID FIELD IN CDB.
+                    log::error!(
+                        "Tried to play audio with start sector {} > end sector {}",
+                        start_sector,
+                        end_sector
+                    );
+                    self.audio_state = AudioState::Stopped;
                     self.common
                         .set_cc(CC_KEY_ILLEGAL_REQUEST, ASC_INVALID_FIELD_IN_CDB);
                     return Ok(ScsiCmdResult::Status(STATUS_CHECK_CONDITION));
                 }
 
-                if start_sector >= session.leadout {
+                let final_leadout = sessions.last().unwrap().leadout;
+                if start_sector >= final_leadout {
                     // [MMC4] 6.17.2.3:
                     // If the starting address is not found the command shall be terminated with CHECK CONDITION status
                     // and SK/ASC/ASCQ values shall be set to ILLEGAL REQUEST/LOGICAL BLOCK ADDRESS OUT

--- a/core/src/mac/scsi/cdrom/mod.rs
+++ b/core/src/mac/scsi/cdrom/mod.rs
@@ -814,7 +814,7 @@ impl ScsiTarget for ScsiTargetCdrom {
         Some(self.backend.as_ref()?.byte_len().div_ceil(self.blocksize))
     }
 
-    fn read(&mut self, block_offset: usize, block_count: usize) -> Result<Vec<u8>> {
+    fn read(&mut self, block_offset: usize, block_count: usize) -> Result<ScsiCmdResult> {
         // If blocks() returns None this will never be called by
         // ScsiTarget::cmd
         let blocksize = self.blocksize;
@@ -828,15 +828,11 @@ impl ScsiTarget for ScsiTargetCdrom {
                 // CD-ROM images may not be exactly aligned on block size
                 // Pad the end to a full block size
                 result.resize(block_count * blocksize, 0);
-                Ok(result)
+                Ok(ScsiCmdResult::DataIn(result))
             }
             Err(CdromError::CheckCondition(cc, asc)) => {
                 self.common.set_cc(cc, asc);
-                Err(anyhow!(
-                    "CD-ROM read error with cc {:02X}h, ASC {:04X}h",
-                    cc,
-                    asc
-                ))
+                Ok(ScsiCmdResult::Status(STATUS_CHECK_CONDITION))
             }
             Err(CdromError::Other(e)) => {
                 self.common
@@ -1198,7 +1194,7 @@ impl ScsiTarget for ScsiTargetCdrom {
                 Ok(ScsiCmdResult::Status(STATUS_GOOD))
             }
             _ => {
-                log::error!("Unknown command {:02X}", cmd[0]);
+                log::error!("Unknown command {:02X}h", cmd[0]);
                 self.common
                     .set_cc(CC_KEY_ILLEGAL_REQUEST, ASC_INVALID_COMMAND);
                 Ok(ScsiCmdResult::Status(STATUS_CHECK_CONDITION))

--- a/core/src/mac/scsi/cdrom/mod.rs
+++ b/core/src/mac/scsi/cdrom/mod.rs
@@ -75,6 +75,14 @@ impl Msf {
         Self { m, s, f }
     }
 
+    fn from_bytes(bytes: [u8; 3]) -> Self {
+        Self::new(bytes[0], bytes[1], bytes[2])
+    }
+
+    fn to_bytes(self) -> [u8; 3] {
+        [self.m, self.s, self.f]
+    }
+
     fn from_sector(mut sector: u32) -> Result<Self> {
         let f = sector % AUDIO_SECTORS_PER_SEC;
         sector /= AUDIO_SECTORS_PER_SEC;
@@ -99,6 +107,8 @@ impl std::fmt::Display for Msf {
 pub struct TrackInfo {
     /// The track number. Note that tracks don't necessarily start at number 1.
     tno: u8,
+    /// The session number where this track resides
+    session: u8,
     /// Control field indicating track format
     control: u8,
     /// Absolute sector number where the track begins
@@ -106,9 +116,14 @@ pub struct TrackInfo {
 }
 
 pub struct SessionInfo {
-    /// Absolute sector number of leadout
+    /// Session number. Always starts at 1.
+    number: u8,
+    /// Value to put in Disc Type field ([MMC4] Table 448)
+    disc_type: u8,
+    /// Absolute sector number of lead-in
+    leadin: u32,
+    /// Absolute sector number of lead-out
     leadout: u32,
-    tracks: Vec<TrackInfo>,
 }
 
 pub enum CdromError {
@@ -136,9 +151,8 @@ pub trait CdromBackend: Send {
 
     fn image_path(&self) -> Option<&Path>;
 
-    /// Return a list of sessions, each containing a list of tracks.
-    /// Unlike tracks, sessions are always numbered starting at 1.
     fn sessions(&self) -> Option<&[SessionInfo]>;
+    fn tracks(&self) -> Option<&[TrackInfo]>;
 
     /// Read a raw 2352-byte sector. Currently used only for CD audio. Other data is read via read_bytes.
     fn read_raw_sector(&self, sector: u32) -> Result<[u8; RAW_SECTOR_LEN]>;
@@ -261,7 +275,7 @@ impl ScsiTargetCdrom {
             return Ok(ScsiCmdResult::Status(STATUS_CHECK_CONDITION));
         };
 
-        let Some(sessions) = backend.sessions() else {
+        let Some(tracks) = backend.tracks() else {
             // Media does not support tracks
             //
             // [PIONEER] 2.28:
@@ -273,6 +287,8 @@ impl ScsiTargetCdrom {
             return Ok(ScsiCmdResult::Status(STATUS_CHECK_CONDITION));
         };
 
+        let sessions = backend.sessions().unwrap();
+
         match format {
             0 => {
                 // Formatted TOC
@@ -281,29 +297,16 @@ impl ScsiTargetCdrom {
                 result.push(0); // TOC Data Length (will be set later)
                 result.push(0);
 
-                // TODO: support multisession discs (All sessions TOC's must be combined)
-                let session = &sessions[0];
-
                 result.push(
-                    session
-                        .tracks
+                    tracks
                         .first()
                         .ok_or_else(|| anyhow!("Track not found"))?
                         .tno,
                 ); // First Track Number
-                result.push(
-                    session
-                        .tracks
-                        .last()
-                        .ok_or_else(|| anyhow!("Track not found"))?
-                        .tno,
-                ); // Last Track Number
+                result.push(tracks.last().ok_or_else(|| anyhow!("Track not found"))?.tno); // Last Track Number
 
                 // Start at the given track or the next available track
-                let track_iter = session
-                    .tracks
-                    .iter()
-                    .skip_while(|t| t.tno < track_or_session);
+                let track_iter = tracks.iter().skip_while(|t| t.tno < track_or_session);
 
                 // Emit track descriptors
                 for t in track_iter {
@@ -319,12 +322,13 @@ impl ScsiTargetCdrom {
 
                 // Emit leadout track descriptor
                 result.push(0); // Reserved
-                result.push((1 << 4) | session.tracks.last().unwrap().control); // ADR/Control
+                result.push((1 << 4) | tracks.last().unwrap().control); // ADR/Control
                 result.push(TRACK_LEADOUT); // Track Number
                 result.push(0); // Reserved
-                result.extend_from_slice(
-                    &self.msf_to_address_field(Msf::from_sector(sessions[0].leadout)?, msf),
-                );
+                result.extend_from_slice(&self.msf_to_address_field(
+                    Msf::from_sector(sessions.last().unwrap().leadout)?,
+                    msf,
+                ));
 
                 // Set data length field
                 let data_length = result.len() - 2;
@@ -341,20 +345,25 @@ impl ScsiTargetCdrom {
                 result.push(0); // TOC Data Length (will be set later)
                 result.push(0);
 
-                result.push(1); // First Session Number (always 1)
-                result.push(sessions.len() as u8); // Last Session Number
+                result.push(sessions.first().unwrap().number); // First Session Number (always 1)
+                result.push(sessions.last().unwrap().number); // Last Session Number
 
-                // This command queries the "first track in the last session" apparently...
-                let first_track = sessions.last().unwrap().tracks.first().unwrap();
+                // This command queries the first track in the last session.
+                let last_session_no = sessions.last().unwrap().number;
+                let first_track_of_last_session = tracks
+                    .iter()
+                    .find(|t| t.session >= last_session_no)
+                    .unwrap();
 
                 // [PIONEER] Table 2-28D: Track Descriptors
                 result.push(0); // Reserved
-                result.push((0x1 << 4) | first_track.control); // ADR/Control
-                result.push(first_track.tno); // First Track Number in Last Session
+                result.push((0x1 << 4) | first_track_of_last_session.control); // ADR/Control
+                result.push(first_track_of_last_session.tno); // First Track Number in Last Session
                 result.push(0); // Reserved
-                result.extend_from_slice(
-                    &self.msf_to_address_field(Msf::from_sector(first_track.sector)?, msf),
-                ); // Absolute CD-ROM Address of the First Track in the Last Session
+                result.extend_from_slice(&self.msf_to_address_field(
+                    Msf::from_sector(first_track_of_last_session.sector)?,
+                    msf,
+                )); // Absolute CD-ROM Address of the First Track in the Last Session
 
                 let data_length = result.len() - 2;
                 result[0..2].copy_from_slice(&u16::to_be_bytes(data_length.try_into()?));
@@ -369,74 +378,114 @@ impl ScsiTargetCdrom {
                 result.push(0); // TOC Data Length (will be filled later)
                 result.push(0);
 
-                result.push(1); // First Complete Session Number (always 1)
-                result.push(sessions.len() as u8); // Last Complete Session Number
+                result.push(sessions.first().unwrap().number); // First Complete Session Number (always 1)
+                result.push(sessions.last().unwrap().number); // Last Complete Session Number
 
                 // track_or_session argument is the session number to start at.
-                // Session numbers start at 1.
-                let session_iter = sessions
-                    .iter()
-                    .skip(track_or_session.saturating_sub(1).into());
+                let track_iter = tracks.iter().skip_while(|t| t.session < track_or_session);
+                let mut session_no = 0;
 
-                for (session_num, session) in session_iter.enumerate() {
-                    let session_num = session_num + 1; // Session Numbers start at 1
+                let get_session = |num: u8| {
+                    (num as usize)
+                        .checked_sub(1)
+                        .and_then(|num| sessions.get(num))
+                };
 
-                    // First track number in the program area
-                    result.push(session_num as u8); // Session Number
-                    result.push((1 << 4) | session.tracks.first().unwrap().control);
-                    result.push(0); // TNO (0 for the lead-in area)
-                    result.push(0xA0); // POINT (First Track number in the program area)
-                    result.push(0); // ATIME (0:0:0 for the lead-in area)
-                    result.push(0);
-                    result.push(0);
-                    result.push(0); // Zero
-                    result.push(session.tracks.first().unwrap().tno); // First Track Number
-                    result.push(0); // Disc Type
-                    result.push(0);
+                for track in track_iter {
+                    if track.session != session_no {
+                        if session_no != 0 {
+                            // Emit descriptors for session gap
+                            // XXX: info based on Weird Al - Running with Scissors; other discs may have different session gap descriptors.
 
-                    // Last track number in the program area
-                    result.push(session_num as u8); // Session Number
-                    result.push((1 << 4) | session.tracks.first().unwrap().control);
-                    result.push(0); // TNO (0 for the lead-in area)
-                    result.push(0xA1); // POINT (Last Track number in the program area)
-                    result.push(0); // ATIME (0:0:0 for the lead-in area)
-                    result.push(0);
-                    result.push(0);
-                    result.push(0); // Zero
-                    result.push(session.tracks.last().unwrap().tno); // Last Track Number
-                    result.push(0);
-                    result.push(0);
+                            // Start time of next possible program
+                            let next_session = get_session(session_no + 1).unwrap();
+                            log::debug!(
+                                "emitting next session descriptor leadin {}",
+                                next_session.leadin
+                            );
+                            result.push(session_no); // Session Number
+                            result.push(5 << 4); // ADR; Control
+                            result.push(0); // TNO (0 for the lead-in area)
+                            result.push(0xB0); // POINT (Start time of next possible program)
+                            result.extend_from_slice(
+                                &Msf::from_sector(next_session.leadin)?.to_bytes(),
+                            ); // Start time of next possible program
+                            result.push(2); // # of pointers in Mode 5
+                            result.extend_from_slice(
+                                &Msf::from_sector(sessions.last().unwrap().leadout)?.to_bytes(),
+                            ); // Maximum start time of outer-most Lead-out area
 
-                    // Start location of the Lead-out area
-                    result.push(session_num as u8); // Session Number
-                    result.push((1 << 4) | session.tracks.first().unwrap().control);
-                    result.push(0); // TNO (0 for the lead-in area)
-                    result.push(0xA2); // POINT (Start location of the Lead-out area)
-                    result.push(0); // ATIME (0:0:0 for the lead-in area)
-                    result.push(0);
-                    result.push(0);
-                    result.push(0); // Zero
-                    let leadout = Msf::from_sector(session.leadout)?;
-                    result.push(leadout.m); // Start position of Lead-out
-                    result.push(leadout.s);
-                    result.push(leadout.f);
+                            // Start time of the first Lead-in Area of the disc
+                            result.push(session_no); // Session Number
+                            result.push(5 << 4); // ADR; Control
+                            result.push(0); // TNO (0 for the lead-in area)
+                            result.push(0xC0); // POINT (Start time of the first Lead-in Area of the disc)
+                            result.push(0); // ATIME (0:0:0 for the lead-in area)
+                            result.push(0);
+                            result.push(0);
+                            result.push(0); // Zero
+                            // FIXME: Weird Al actually puts 95:00:00 here? where does that come from?
+                            result.extend_from_slice(
+                                &Msf::from_sector(sessions.first().unwrap().leadin)?.to_bytes(),
+                            ); // Start time of the first Lead-in Area of the disc)
+                        }
 
-                    for track in &session.tracks {
-                        result.push(session_num as u8); // Session Number
-                        result.push((1 << 4) | track.control); // ADR/Control
+                        session_no = track.session;
+                        let session = get_session(session_no).unwrap();
+
+                        // First track number in the program area
+                        result.push(session_no); // Session Number
+                        result.push((1 << 4) | track.control);
                         result.push(0); // TNO (0 for the lead-in area)
-                        result.push(track.tno); // POINT (0-99 for tracks)
+                        result.push(0xA0); // POINT (First Track number in the program area)
                         result.push(0); // ATIME (0:0:0 for the lead-in area)
                         result.push(0);
                         result.push(0);
                         result.push(0); // Zero
-                        let track_msf = Msf::from_sector(track.sector)?;
-                        result.push(track_msf.m); // Start position of track
-                        result.push(track_msf.s);
-                        result.push(track_msf.f);
+                        result.push(track.tno); // First Track Number
+                        result.push(session.disc_type); // Disc Type
+                        result.push(0);
+
+                        // Last track number in the program area
+                        result.push(session_no); // Session Number
+                        result.push((1 << 4) | track.control);
+                        result.push(0); // TNO (0 for the lead-in area)
+                        result.push(0xA1); // POINT (Last Track number in the program area)
+                        result.push(0); // ATIME (0:0:0 for the lead-in area)
+                        result.push(0);
+                        result.push(0);
+                        result.push(0); // Zero
+                        let last_track_in_session = tracks
+                            .iter()
+                            .rev()
+                            .find(|t| t.session == session_no)
+                            .unwrap();
+                        result.push(last_track_in_session.tno); // Last Track Number
+                        result.push(0);
+                        result.push(0);
+
+                        // Start location of the Lead-out area
+                        result.push(session_no); // Session Number
+                        result.push((1 << 4) | track.control);
+                        result.push(0); // TNO (0 for the lead-in area)
+                        result.push(0xA2); // POINT (Start location of the Lead-out area)
+                        result.push(0); // ATIME (0:0:0 for the lead-in area)
+                        result.push(0);
+                        result.push(0);
+                        result.push(0); // Zero
+                        let leadout = Msf::from_sector(get_session(session_no).unwrap().leadout)?;
+                        result.extend_from_slice(&leadout.to_bytes()); // Start position of Lead-out
                     }
 
-                    // TODO: emit POINT's 0xB0 and 0xC0 for multisession discs
+                    result.push(track.session); // Session Number
+                    result.push((1 << 4) | track.control); // ADR/Control
+                    result.push(0); // TNO (0 for the lead-in area)
+                    result.push(track.tno); // POINT (0-99 for tracks)
+                    result.push(0); // ATIME (0:0:0 for the lead-in area)
+                    result.push(0);
+                    result.push(0);
+                    result.push(0); // Zero
+                    result.extend_from_slice(&Msf::from_sector(track.sector)?.to_bytes()); // Start position of track
                 }
 
                 let data_length = result.len() - 2;
@@ -559,8 +608,7 @@ impl ScsiTargetCdrom {
     }
 
     fn get_track_at_sector(&self, sector: u32) -> Option<&TrackInfo> {
-        // TODO: support multi-session discs
-        let tracks = &self.backend.as_ref()?.sessions()?[0].tracks;
+        let tracks = self.backend.as_ref()?.tracks()?;
         tracks
             .iter()
             .rev()
@@ -698,8 +746,7 @@ impl ScsiTarget for ScsiTargetCdrom {
                 // If a Logical Unit does not support high speed CD-R/RW recording, the Logical Unit should not
                 // return mode page data after byte 26.
                 let mut data = vec![0; 0x18];
-                data[2] = 1; // Audio Play
-                // TODO: support more features such as Mode2 sectors, multiple sessions, etc.
+                data[2] = (1 << 6) | (1 << 5) | (1 << 4) | 1; // Multi Session; Mode 2 Form 2; Mode 2 Form 1; Audio Play
                 data[4] = (0b001 << 5) | (1 << 3); // Tray type loading mechanism; Eject
                 data[5] = (1 << 1) | 1; // Separate Channel Mute; Separate volume levels
                 data[8..=9].copy_from_slice(&256u16.to_be_bytes()); // Number of Volume Levels Supported
@@ -975,8 +1022,8 @@ impl ScsiTarget for ScsiTargetCdrom {
             }
             // PLAY AUDIO MSF
             0x47 => {
-                let start_msf = Msf::new(cmd[3], cmd[4], cmd[5]);
-                let end_msf = Msf::new(cmd[6], cmd[7], cmd[8]);
+                let start_msf = Msf::from_bytes(cmd[3..=5].try_into().unwrap());
+                let end_msf = Msf::from_bytes(cmd[6..=8].try_into().unwrap());
 
                 log::debug!("PLAY AUDIO MSF start {} end {}", start_msf, end_msf);
 
@@ -1093,14 +1140,11 @@ impl ScsiTarget for ScsiTargetCdrom {
                     return Ok(ScsiCmdResult::Status(STATUS_CHECK_CONDITION));
                 };
 
-                let Some(sessions) = backend.sessions() else {
+                let Some(tracks) = backend.tracks() else {
                     self.common
                         .set_cc(CC_KEY_MEDIUM_ERROR, ASC_MEDIUM_NOT_PRESENT);
                     return Ok(ScsiCmdResult::Status(STATUS_CHECK_CONDITION));
                 };
-
-                // TODO: support multi-session discs
-                let mut tracks = sessions[0].tracks.iter();
 
                 let direct = (cmd[1] >> 4) & 0x1; // Scan forwards if set, backwards if unset.
                 let addr_type = (cmd[9] >> 6) & 0x3;
@@ -1113,9 +1157,9 @@ impl ScsiTarget for ScsiTargetCdrom {
                 );
 
                 // Convert start address to sector
-                let _start_addr = match addr_type {
+                let _start_sector = match addr_type {
                     // Logical Block Address
-                    0b00 => u32::from_be_bytes(start_addr.try_into()?),
+                    0b00 => LBA_START_SECTOR + u32::from_be_bytes(start_addr.try_into()?),
                     // CD absolute time
                     0b01 => Msf::new(start_addr[1], start_addr[2], start_addr[3]).to_sector(),
                     // Track Number
@@ -1123,6 +1167,7 @@ impl ScsiTarget for ScsiTargetCdrom {
                         // Start at the given track or the next available track
                         // FIXME: what should happen if specified track is not available?
                         let track = tracks
+                            .iter()
                             .find(|t| t.tno >= start_addr[3])
                             .ok_or_else(|| anyhow!("Failed to find track"))?;
                         track.sector

--- a/core/src/mac/scsi/cdrom/mod.rs
+++ b/core/src/mac/scsi/cdrom/mod.rs
@@ -140,6 +140,13 @@ impl From<anyhow::Error> for CdromError {
     }
 }
 
+pub struct RawSector {
+    data: [u8; RAW_SECTOR_LEN],
+    /// CONTROL field of sub-channel data. Indicates audio or data track.
+    control: u8,
+    // TODO: add fields for other sub-channel data (position, track/index number, etc.)
+}
+
 pub trait CdromBackend: Send {
     fn byte_len(&self) -> usize;
 
@@ -156,7 +163,7 @@ pub trait CdromBackend: Send {
     fn tracks(&self) -> Option<&[TrackInfo]>;
 
     /// Read a raw 2352-byte sector. Currently used only for CD audio. Other data is read via read_bytes.
-    fn read_raw_sector(&self, sector: u32) -> Result<[u8; RAW_SECTOR_LEN]>;
+    fn read_raw_sector(&self, sector: u32) -> Result<RawSector>;
 }
 
 #[derive(PartialEq, Eq, Serialize, Deserialize)]
@@ -555,8 +562,9 @@ impl ScsiTargetCdrom {
 
         let samples = backend.read_raw_sector(self.audio_pos);
         match samples {
-            Ok(samples) => {
+            Ok(samples) if samples.control == AUDIO_TRACK => {
                 let mut samples = samples
+                    .data
                     .chunks_exact(2)
                     .map(|s| i16::from_le_bytes(s.try_into().unwrap()));
                 // FIXME: can we avoid converting to float by setting up a signed 16-bit PCM audio sink?
@@ -573,6 +581,7 @@ impl ScsiTargetCdrom {
 
                 audio_sink.send(Box::new(out_samples))?;
             }
+            Ok(_) => log::warn!("Tried to play from non-audio track"),
             Err(e) => log::warn!(
                 "Failed to read raw samples from sector {}: {}",
                 self.audio_pos,
@@ -606,6 +615,16 @@ impl ScsiTargetCdrom {
     }
 }
 
+fn get_track_at_sector(tracks: &[TrackInfo], sector: u32) -> Option<&TrackInfo> {
+    tracks
+        .iter()
+        .rev()
+        .find(|t| t.sector <= sector)
+        // XXX: if sector is before the first track, just return the first track.
+        // This occurs if Track 1 begins with an Index 0 pregap.
+        .or_else(|| tracks.first())
+}
+
 impl ScsiTargetCdrom {
     fn load_cue(&mut self, path: &Path) -> Result<()> {
         self.backend = Some(Box::new(CuesheetCdromBackend::new(path)?));
@@ -616,13 +635,7 @@ impl ScsiTargetCdrom {
 
     fn get_track_at_sector(&self, sector: u32) -> Option<&TrackInfo> {
         let tracks = self.backend.as_ref()?.tracks()?;
-        tracks
-            .iter()
-            .rev()
-            .find(|t| t.sector <= sector)
-            // XXX: if sector is before the first track, just return the first track.
-            // This occurs if Track 1 begins with an Index 0 pregap.
-            .or_else(|| tracks.first())
+        get_track_at_sector(tracks, sector)
     }
 }
 

--- a/core/src/mac/scsi/cdrom/mod.rs
+++ b/core/src/mac/scsi/cdrom/mod.rs
@@ -587,12 +587,18 @@ impl ScsiTargetCdrom {
 
                 audio_sink.send(Box::new(out_samples))?;
             }
-            Ok(_) => log::warn!("Tried to play from non-audio track"),
-            Err(e) => log::warn!(
-                "Failed to read raw samples from sector {}: {}",
-                self.audio_pos,
-                e
-            ),
+            Ok(_) => {
+                log::warn!("Tried to play from non-audio track");
+                self.audio_state = AudioState::Stopped;
+            }
+            Err(e) => {
+                log::warn!(
+                    "Failed to read raw samples from sector {}: {}",
+                    self.audio_pos,
+                    e
+                );
+                self.audio_state = AudioState::Stopped;
+            }
         }
 
         self.audio_pos += 1;
@@ -1027,14 +1033,14 @@ impl ScsiTarget for ScsiTargetCdrom {
                 let track = cmd[6];
                 let alloc_len = u16::from_be_bytes(cmd[7..=8].try_into()?) as usize;
 
-                log::debug!(
-                    "READ TOC msf {} format {} control {} track {} alloc_len {}",
-                    msf,
-                    format,
-                    control,
-                    track,
-                    alloc_len
-                );
+                // log::debug!(
+                //     "READ TOC msf {} format {} control {} track {} alloc_len {}",
+                //     msf,
+                //     format,
+                //     control,
+                //     track,
+                //     alloc_len
+                // );
 
                 if control != 0 {
                     log::warn!("Unimplemented READ TOC control 0x{:X}", control);

--- a/core/src/mac/scsi/cdrom/mod.rs
+++ b/core/src/mac/scsi/cdrom/mod.rs
@@ -63,23 +63,6 @@ const LBA_START_SECTOR: u32 = LBA_START_MSF.to_sector();
 /// Number of sectors per second of audio
 const AUDIO_SECTORS_PER_SEC: u32 = 75;
 
-// "Wait, why do we have BCD conversion functions? Doesn't the MMC standard say
-// each field is converted to binary by the drive?"
-//
-// Yes, but classic Macs have very old, pre-standardized CD-ROM drives. Unlike
-// modern drives, these old drives return BCD-encoded fields from their READ TOC
-// commands, which matches the encoding on the disc itself.
-//
-// This can be confirmed by examining very old Linux drivers.
-
-fn bin_to_bcd(bin: u8) -> u8 {
-    ((bin / 10) << 4) | (bin % 10)
-}
-
-fn bcd_to_bin(bcd: u8) -> u8 {
-    (bcd >> 4) * 10 + (bcd & 0xf)
-}
-
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 struct Msf {
     m: u8,
@@ -92,13 +75,12 @@ impl Msf {
         Self { m, s, f }
     }
 
-    fn from_bcd_bytes(bytes: [u8; 3]) -> Self {
-        let [m, s, f] = bytes.map(bcd_to_bin);
-        Self::new(m, s, f)
+    fn from_bytes(bytes: [u8; 3]) -> Self {
+        Self::new(bytes[0], bytes[1], bytes[2])
     }
 
-    fn to_bcd_bytes(self) -> [u8; 3] {
-        [self.m, self.s, self.f].map(bin_to_bcd)
+    fn to_bytes(self) -> [u8; 3] {
+        [self.m, self.s, self.f]
     }
 
     fn from_sector(mut sector: u32) -> Result<Self> {
@@ -264,16 +246,10 @@ impl ScsiTargetCdrom {
         self_
     }
 
-    fn msf_to_address_field(&self, msf: Msf, msf_format: bool, use_bcd: bool) -> [u8; 4] {
+    fn msf_to_address_field(&self, msf: Msf, msf_format: bool) -> [u8; 4] {
         if msf_format {
             // [UNI-MAINZ] Table 237: MSF address format
-            if use_bcd {
-                let mut result = [0u8; 4];
-                result[1..].copy_from_slice(&msf.to_bcd_bytes());
-                result
-            } else {
-                [0, msf.m, msf.s, msf.f]
-            }
+            [0, msf.m, msf.s, msf.f]
         } else {
             // FIXME: is this correct? I can't find any software that sets a non-2048 blocksize.
             let lba =
@@ -339,11 +315,9 @@ impl ScsiTargetCdrom {
                     result.push((1 << 4) | t.control); // ADR/Control
                     result.push(t.tno); // Track Number
                     result.push(0); // Reserved
-                    result.extend_from_slice(&self.msf_to_address_field(
-                        Msf::from_sector(t.sector)?,
-                        msf,
-                        true,
-                    ));
+                    result.extend_from_slice(
+                        &self.msf_to_address_field(Msf::from_sector(t.sector)?, msf),
+                    );
                     // Absolute CD-ROM Address
                 }
 
@@ -355,7 +329,6 @@ impl ScsiTargetCdrom {
                 result.extend_from_slice(&self.msf_to_address_field(
                     Msf::from_sector(sessions.last().unwrap().leadout)?,
                     msf,
-                    true,
                 ));
 
                 // Set data length field
@@ -393,7 +366,6 @@ impl ScsiTargetCdrom {
                 result.extend_from_slice(&self.msf_to_address_field(
                     Msf::from_sector(first_track_of_last_session.sector)?,
                     msf,
-                    true,
                 )); // Absolute CD-ROM Address of the First Track in the Last Session
 
                 let data_length = result.len() - 2;
@@ -441,11 +413,11 @@ impl ScsiTargetCdrom {
                             result.push(0); // TNO (0 for the lead-in area)
                             result.push(0xB0); // POINT (Start time of next possible program)
                             result.extend_from_slice(
-                                &Msf::from_sector(next_session.leadin)?.to_bcd_bytes(),
+                                &Msf::from_sector(next_session.leadin)?.to_bytes(),
                             ); // Start time of next possible program
                             result.push(2); // # of pointers in Mode 5
                             result.extend_from_slice(
-                                &Msf::from_sector(sessions.last().unwrap().leadout)?.to_bcd_bytes(),
+                                &Msf::from_sector(sessions.last().unwrap().leadout)?.to_bytes(),
                             ); // Maximum start time of outer-most Lead-out area
 
                             // Start time of the first Lead-in Area of the disc
@@ -459,7 +431,7 @@ impl ScsiTargetCdrom {
                             result.push(0); // Zero
                             // FIXME: Weird Al actually puts 95:00:00 here? where does that come from?
                             result.extend_from_slice(
-                                &Msf::from_sector(sessions.first().unwrap().leadin)?.to_bcd_bytes(),
+                                &Msf::from_sector(sessions.first().unwrap().leadin)?.to_bytes(),
                             ); // Start time of the first Lead-in Area of the disc)
                         }
 
@@ -507,7 +479,7 @@ impl ScsiTargetCdrom {
                         result.push(0);
                         result.push(0); // Zero
                         let leadout = Msf::from_sector(get_session(session_no).unwrap().leadout)?;
-                        result.extend_from_slice(&leadout.to_bcd_bytes()); // Start position of Lead-out
+                        result.extend_from_slice(&leadout.to_bytes()); // Start position of Lead-out
                     }
 
                     result.push(track.session); // Session Number
@@ -518,7 +490,7 @@ impl ScsiTargetCdrom {
                     result.push(0);
                     result.push(0);
                     result.push(0); // Zero
-                    result.extend_from_slice(&Msf::from_sector(track.sector)?.to_bcd_bytes()); // Start position of track
+                    result.extend_from_slice(&Msf::from_sector(track.sector)?.to_bytes()); // Start position of track
                 }
 
                 let data_length = result.len() - 2;
@@ -988,22 +960,19 @@ impl ScsiTarget for ScsiTargetCdrom {
                         result.push((1 << 4) | track.control); // ADR/Control
                         result.push(track.tno); // Track Number
                         result.push(1); // Index Number (TODO: Find correct index number)
-                        // XXX: looks like Apple CD Audio Player expects this field to NOT be in BCD...
-                        result.extend_from_slice(&self.msf_to_address_field(
-                            Msf::from_sector(self.audio_pos)?,
-                            msf != 0,
-                            false,
-                        ));
+                        result.extend_from_slice(
+                            &self.msf_to_address_field(Msf::from_sector(self.audio_pos)?, msf != 0),
+                        );
                         // Track relative position can be negative if the audio position is in a track pregap.
                         let track_relative = self.audio_pos as i32 - track.sector as i32;
                         if let Ok(track_relative) = TryInto::<u32>::try_into(track_relative) {
                             // Track relative position is positive.
-                            // XXX: looks like Apple CD Audio Player expects this field to NOT be in BCD...
-                            result.extend_from_slice(&self.msf_to_address_field(
-                                Msf::from_sector(track_relative)?,
-                                msf != 0,
-                                false,
-                            ));
+                            result.extend_from_slice(
+                                &self.msf_to_address_field(
+                                    Msf::from_sector(track_relative)?,
+                                    msf != 0,
+                                ),
+                            );
                         } else if msf != 0 {
                             // Track relative position is negative (MSF).
                             // [MMC4] 6.29.3.3:
@@ -1060,8 +1029,10 @@ impl ScsiTarget for ScsiTargetCdrom {
             }
             // PLAY AUDIO MSF
             0x47 => {
-                let start_msf_bytes: [u8; 3] = cmd[3..=5].try_into().unwrap();
-                let end_msf = Msf::from_bcd_bytes(cmd[6..=8].try_into().unwrap());
+                let start_msf = Msf::from_bytes(cmd[3..=5].try_into().unwrap());
+                let end_msf = Msf::from_bytes(cmd[6..=8].try_into().unwrap());
+
+                log::debug!("PLAY AUDIO MSF start {} end {}", start_msf, end_msf);
 
                 let Some(backend) = &self.backend else {
                     self.common
@@ -1075,14 +1046,20 @@ impl ScsiTarget for ScsiTargetCdrom {
                     return Ok(ScsiCmdResult::Status(STATUS_CHECK_CONDITION));
                 };
 
+                // [PIONEER]: 2.13:
+                // If the starting address is not found, or if the address is not within an audio track, or if a not ready
+                // condition exists, the drive will terminate with a Check Condition status.
+                let session = &sessions[0];
+                // TODO: support multisession discs
+
                 // [MMC4] 6.17.2.3:
                 // If the Starting Minutes, Seconds, and Frame Fields are set to FFh, the Starting address is taken from
                 // the Current Optical Head location. This allows the Audio Ending address to be changed without
                 // interrupting the current playback operation.
-                let start_sector = if start_msf_bytes == [0xff, 0xff, 0xff] {
+                let start_sector = if start_msf == Msf::new(255, 255, 255) {
                     self.audio_pos
                 } else {
-                    Msf::from_bcd_bytes(start_msf_bytes).to_sector()
+                    start_msf.to_sector()
                 };
 
                 let end_sector = end_msf.to_sector();
@@ -1096,13 +1073,12 @@ impl ScsiTarget for ScsiTargetCdrom {
                     return Ok(ScsiCmdResult::Status(STATUS_CHECK_CONDITION));
                 }
 
-                let final_leadout = sessions.last().unwrap().leadout;
-                if start_sector >= final_leadout {
+                if start_sector >= session.leadout {
                     // [MMC4] 6.17.2.3:
                     // If the starting address is not found the command shall be terminated with CHECK CONDITION status
                     // and SK/ASC/ASCQ values shall be set to ILLEGAL REQUEST/LOGICAL BLOCK ADDRESS OUT
                     // OF RANGE.
-                    log::error!("Tried to play audio from invalid sector {}", start_sector);
+                    log::error!("Tried to play audio from invalid location {}", start_msf);
                     self.common.set_cc(
                         CC_KEY_ILLEGAL_REQUEST,
                         ASC_LOGICAL_BLOCK_ADDRESS_OUT_OF_RANGE,
@@ -1119,10 +1095,7 @@ impl ScsiTarget for ScsiTargetCdrom {
                     // If the address is not within an audio track the command shall be terminated with
                     // CHECK CONDITION status and SK/ASC/ASCQ values shall be set to ILLEGAL REQUEST/ILLEGAL
                     // MODE FOR THIS TRACK or ILLEGAL REQUEST/INCOMPATIBLE MEDIUM INSTALLED.
-                    log::error!(
-                        "Tried to play audio from non-audio track at sector {}",
-                        start_sector
-                    );
+                    log::error!("Tried to play audio from non-audio track at {}", start_msf);
                     self.common
                         .set_cc(CC_KEY_ILLEGAL_REQUEST, ASC_ILLEGAL_MODE_FOR_THIS_TRACK);
                     return Ok(ScsiCmdResult::Status(STATUS_CHECK_CONDITION));

--- a/core/src/mac/scsi/cdrom/mod.rs
+++ b/core/src/mac/scsi/cdrom/mod.rs
@@ -63,6 +63,23 @@ const LBA_START_SECTOR: u32 = LBA_START_MSF.to_sector();
 /// Number of sectors per second of audio
 const AUDIO_SECTORS_PER_SEC: u32 = 75;
 
+// "Wait, why do we have BCD conversion functions? Doesn't the MMC standard say
+// each field is converted to binary by the drive?"
+//
+// Yes, but classic Macs have very old, pre-standardized CD-ROM drives. Unlike
+// modern drives, these old drives return BCD-encoded fields from their READ TOC
+// commands, which matches the encoding on the disc itself.
+//
+// This can be confirmed by examining very old Linux drivers.
+
+fn bin_to_bcd(bin: u8) -> u8 {
+    ((bin / 10) << 4) | (bin % 10)
+}
+
+fn bcd_to_bin(bcd: u8) -> u8 {
+    (bcd >> 4) * 10 + (bcd & 0xf)
+}
+
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 struct Msf {
     m: u8,
@@ -75,12 +92,13 @@ impl Msf {
         Self { m, s, f }
     }
 
-    fn from_bytes(bytes: [u8; 3]) -> Self {
-        Self::new(bytes[0], bytes[1], bytes[2])
+    fn from_bcd_bytes(bytes: [u8; 3]) -> Self {
+        let [m, s, f] = bytes.map(bcd_to_bin);
+        Self::new(m, s, f)
     }
 
-    fn to_bytes(self) -> [u8; 3] {
-        [self.m, self.s, self.f]
+    fn to_bcd_bytes(self) -> [u8; 3] {
+        [self.m, self.s, self.f].map(bin_to_bcd)
     }
 
     fn from_sector(mut sector: u32) -> Result<Self> {
@@ -246,10 +264,16 @@ impl ScsiTargetCdrom {
         self_
     }
 
-    fn msf_to_address_field(&self, msf: Msf, msf_format: bool) -> [u8; 4] {
+    fn msf_to_address_field(&self, msf: Msf, msf_format: bool, use_bcd: bool) -> [u8; 4] {
         if msf_format {
             // [UNI-MAINZ] Table 237: MSF address format
-            [0, msf.m, msf.s, msf.f]
+            if use_bcd {
+                let mut result = [0u8; 4];
+                result[1..].copy_from_slice(&msf.to_bcd_bytes());
+                result
+            } else {
+                [0, msf.m, msf.s, msf.f]
+            }
         } else {
             // FIXME: is this correct? I can't find any software that sets a non-2048 blocksize.
             let lba =
@@ -315,9 +339,11 @@ impl ScsiTargetCdrom {
                     result.push((1 << 4) | t.control); // ADR/Control
                     result.push(t.tno); // Track Number
                     result.push(0); // Reserved
-                    result.extend_from_slice(
-                        &self.msf_to_address_field(Msf::from_sector(t.sector)?, msf),
-                    );
+                    result.extend_from_slice(&self.msf_to_address_field(
+                        Msf::from_sector(t.sector)?,
+                        msf,
+                        true,
+                    ));
                     // Absolute CD-ROM Address
                 }
 
@@ -329,6 +355,7 @@ impl ScsiTargetCdrom {
                 result.extend_from_slice(&self.msf_to_address_field(
                     Msf::from_sector(sessions.last().unwrap().leadout)?,
                     msf,
+                    true,
                 ));
 
                 // Set data length field
@@ -366,6 +393,7 @@ impl ScsiTargetCdrom {
                 result.extend_from_slice(&self.msf_to_address_field(
                     Msf::from_sector(first_track_of_last_session.sector)?,
                     msf,
+                    true,
                 )); // Absolute CD-ROM Address of the First Track in the Last Session
 
                 let data_length = result.len() - 2;
@@ -413,11 +441,11 @@ impl ScsiTargetCdrom {
                             result.push(0); // TNO (0 for the lead-in area)
                             result.push(0xB0); // POINT (Start time of next possible program)
                             result.extend_from_slice(
-                                &Msf::from_sector(next_session.leadin)?.to_bytes(),
+                                &Msf::from_sector(next_session.leadin)?.to_bcd_bytes(),
                             ); // Start time of next possible program
                             result.push(2); // # of pointers in Mode 5
                             result.extend_from_slice(
-                                &Msf::from_sector(sessions.last().unwrap().leadout)?.to_bytes(),
+                                &Msf::from_sector(sessions.last().unwrap().leadout)?.to_bcd_bytes(),
                             ); // Maximum start time of outer-most Lead-out area
 
                             // Start time of the first Lead-in Area of the disc
@@ -431,7 +459,7 @@ impl ScsiTargetCdrom {
                             result.push(0); // Zero
                             // FIXME: Weird Al actually puts 95:00:00 here? where does that come from?
                             result.extend_from_slice(
-                                &Msf::from_sector(sessions.first().unwrap().leadin)?.to_bytes(),
+                                &Msf::from_sector(sessions.first().unwrap().leadin)?.to_bcd_bytes(),
                             ); // Start time of the first Lead-in Area of the disc)
                         }
 
@@ -479,7 +507,7 @@ impl ScsiTargetCdrom {
                         result.push(0);
                         result.push(0); // Zero
                         let leadout = Msf::from_sector(get_session(session_no).unwrap().leadout)?;
-                        result.extend_from_slice(&leadout.to_bytes()); // Start position of Lead-out
+                        result.extend_from_slice(&leadout.to_bcd_bytes()); // Start position of Lead-out
                     }
 
                     result.push(track.session); // Session Number
@@ -490,7 +518,7 @@ impl ScsiTargetCdrom {
                     result.push(0);
                     result.push(0);
                     result.push(0); // Zero
-                    result.extend_from_slice(&Msf::from_sector(track.sector)?.to_bytes()); // Start position of track
+                    result.extend_from_slice(&Msf::from_sector(track.sector)?.to_bcd_bytes()); // Start position of track
                 }
 
                 let data_length = result.len() - 2;
@@ -960,19 +988,22 @@ impl ScsiTarget for ScsiTargetCdrom {
                         result.push((1 << 4) | track.control); // ADR/Control
                         result.push(track.tno); // Track Number
                         result.push(1); // Index Number (TODO: Find correct index number)
-                        result.extend_from_slice(
-                            &self.msf_to_address_field(Msf::from_sector(self.audio_pos)?, msf != 0),
-                        );
+                        // XXX: looks like Apple CD Audio Player expects this field to NOT be in BCD...
+                        result.extend_from_slice(&self.msf_to_address_field(
+                            Msf::from_sector(self.audio_pos)?,
+                            msf != 0,
+                            false,
+                        ));
                         // Track relative position can be negative if the audio position is in a track pregap.
                         let track_relative = self.audio_pos as i32 - track.sector as i32;
                         if let Ok(track_relative) = TryInto::<u32>::try_into(track_relative) {
                             // Track relative position is positive.
-                            result.extend_from_slice(
-                                &self.msf_to_address_field(
-                                    Msf::from_sector(track_relative)?,
-                                    msf != 0,
-                                ),
-                            );
+                            // XXX: looks like Apple CD Audio Player expects this field to NOT be in BCD...
+                            result.extend_from_slice(&self.msf_to_address_field(
+                                Msf::from_sector(track_relative)?,
+                                msf != 0,
+                                false,
+                            ));
                         } else if msf != 0 {
                             // Track relative position is negative (MSF).
                             // [MMC4] 6.29.3.3:
@@ -1029,10 +1060,8 @@ impl ScsiTarget for ScsiTargetCdrom {
             }
             // PLAY AUDIO MSF
             0x47 => {
-                let start_msf = Msf::from_bytes(cmd[3..=5].try_into().unwrap());
-                let end_msf = Msf::from_bytes(cmd[6..=8].try_into().unwrap());
-
-                log::debug!("PLAY AUDIO MSF start {} end {}", start_msf, end_msf);
+                let start_msf_bytes: [u8; 3] = cmd[3..=5].try_into().unwrap();
+                let end_msf = Msf::from_bcd_bytes(cmd[6..=8].try_into().unwrap());
 
                 let Some(backend) = &self.backend else {
                     self.common
@@ -1046,20 +1075,14 @@ impl ScsiTarget for ScsiTargetCdrom {
                     return Ok(ScsiCmdResult::Status(STATUS_CHECK_CONDITION));
                 };
 
-                // [PIONEER]: 2.13:
-                // If the starting address is not found, or if the address is not within an audio track, or if a not ready
-                // condition exists, the drive will terminate with a Check Condition status.
-                let session = &sessions[0];
-                // TODO: support multisession discs
-
                 // [MMC4] 6.17.2.3:
                 // If the Starting Minutes, Seconds, and Frame Fields are set to FFh, the Starting address is taken from
                 // the Current Optical Head location. This allows the Audio Ending address to be changed without
                 // interrupting the current playback operation.
-                let start_sector = if start_msf == Msf::new(255, 255, 255) {
+                let start_sector = if start_msf_bytes == [0xff, 0xff, 0xff] {
                     self.audio_pos
                 } else {
-                    start_msf.to_sector()
+                    Msf::from_bcd_bytes(start_msf_bytes).to_sector()
                 };
 
                 let end_sector = end_msf.to_sector();
@@ -1073,12 +1096,13 @@ impl ScsiTarget for ScsiTargetCdrom {
                     return Ok(ScsiCmdResult::Status(STATUS_CHECK_CONDITION));
                 }
 
-                if start_sector >= session.leadout {
+                let final_leadout = sessions.last().unwrap().leadout;
+                if start_sector >= final_leadout {
                     // [MMC4] 6.17.2.3:
                     // If the starting address is not found the command shall be terminated with CHECK CONDITION status
                     // and SK/ASC/ASCQ values shall be set to ILLEGAL REQUEST/LOGICAL BLOCK ADDRESS OUT
                     // OF RANGE.
-                    log::error!("Tried to play audio from invalid location {}", start_msf);
+                    log::error!("Tried to play audio from invalid sector {}", start_sector);
                     self.common.set_cc(
                         CC_KEY_ILLEGAL_REQUEST,
                         ASC_LOGICAL_BLOCK_ADDRESS_OUT_OF_RANGE,
@@ -1095,7 +1119,10 @@ impl ScsiTarget for ScsiTargetCdrom {
                     // If the address is not within an audio track the command shall be terminated with
                     // CHECK CONDITION status and SK/ASC/ASCQ values shall be set to ILLEGAL REQUEST/ILLEGAL
                     // MODE FOR THIS TRACK or ILLEGAL REQUEST/INCOMPATIBLE MEDIUM INSTALLED.
-                    log::error!("Tried to play audio from non-audio track at {}", start_msf);
+                    log::error!(
+                        "Tried to play audio from non-audio track at sector {}",
+                        start_sector
+                    );
                     self.common
                         .set_cc(CC_KEY_ILLEGAL_REQUEST, ASC_ILLEGAL_MODE_FOR_THIS_TRACK);
                     return Ok(ScsiCmdResult::Status(STATUS_CHECK_CONDITION));

--- a/core/src/mac/scsi/disk.rs
+++ b/core/src/mac/scsi/disk.rs
@@ -5,6 +5,8 @@ use serde::{Deserialize, Serialize};
 use std::path::Path;
 
 use crate::debuggable::Debuggable;
+use crate::mac::scsi::ASC_INVALID_COMMAND;
+use crate::mac::scsi::CC_KEY_ILLEGAL_REQUEST;
 use crate::mac::scsi::STATUS_CHECK_CONDITION;
 use crate::mac::scsi::STATUS_GOOD;
 use crate::mac::scsi::ScsiCmdResult;
@@ -207,10 +209,12 @@ impl ScsiTarget for ScsiTargetDisk {
         Some(self.backend().byte_len() / DISK_BLOCKSIZE)
     }
 
-    fn read(&mut self, block_offset: usize, block_count: usize) -> Result<Vec<u8>> {
+    fn read(&mut self, block_offset: usize, block_count: usize) -> Result<ScsiCmdResult> {
         let offset = block_offset * DISK_BLOCKSIZE;
         let length = block_count * DISK_BLOCKSIZE;
-        Ok(self.backend().read_bytes(offset, length))
+        Ok(ScsiCmdResult::DataIn(
+            self.backend().read_bytes(offset, length),
+        ))
     }
 
     fn write(&mut self, block_offset: usize, data: &[u8]) {
@@ -223,7 +227,9 @@ impl ScsiTarget for ScsiTargetDisk {
     }
 
     fn specific_cmd(&mut self, cmd: &[u8], _outdata: Option<&[u8]>) -> Result<ScsiCmdResult> {
-        log::error!("Unknown command {:02X}", cmd[0]);
+        log::error!("Unknown command {:02X}h", cmd[0]);
+        self.common
+            .set_cc(CC_KEY_ILLEGAL_REQUEST, ASC_INVALID_COMMAND);
         Ok(ScsiCmdResult::Status(STATUS_CHECK_CONDITION))
     }
 

--- a/core/src/mac/scsi/ethernet.rs
+++ b/core/src/mac/scsi/ethernet.rs
@@ -781,7 +781,7 @@ impl ScsiTarget for ScsiTargetEthernet {
         None
     }
 
-    fn read(&mut self, _block_offset: usize, _block_count: usize) -> Result<Vec<u8>> {
+    fn read(&mut self, _block_offset: usize, _block_count: usize) -> Result<ScsiCmdResult> {
         unreachable!()
     }
 

--- a/core/src/mac/scsi/mod.rs
+++ b/core/src/mac/scsi/mod.rs
@@ -83,8 +83,10 @@ const fn scsi_cmd_len(cmdnum: u8) -> Option<usize> {
         // BlueSCSI Toolbox commands
         | 0xD0..=0xD9
         => Some(10),
+        // REPORT KEY
+        0xA4
         // READ DVD STRUCTURE
-        0xAD
+        | 0xAD
         => Some(12),
         _ => {
             None

--- a/core/src/mac/scsi/mod.rs
+++ b/core/src/mac/scsi/mod.rs
@@ -74,6 +74,8 @@ const fn scsi_cmd_len(cmdnum: u8) -> Option<usize> {
         | 0x47
         // PAUSE/RESUME
         | 0x4B
+        // READ DISC INFORMATION
+        | 0x51
         // MODE SENSE(10)
         | 0x5A
         // AUDIO SCAN (1)
@@ -81,6 +83,9 @@ const fn scsi_cmd_len(cmdnum: u8) -> Option<usize> {
         // BlueSCSI Toolbox commands
         | 0xD0..=0xD9
         => Some(10),
+        // READ DVD STRUCTURE
+        0xAD
+        => Some(12),
         _ => {
             None
         }

--- a/core/src/mac/scsi/target.rs
+++ b/core/src/mac/scsi/target.rs
@@ -122,7 +122,7 @@ pub(crate) trait ScsiTarget: Send + Debuggable {
     // For block devices
     fn blocksize(&self) -> Option<usize>;
     fn blocks(&self) -> Option<usize>;
-    fn read(&mut self, block_offset: usize, block_count: usize) -> Result<Vec<u8>>;
+    fn read(&mut self, block_offset: usize, block_count: usize) -> Result<ScsiCmdResult>;
     fn write(&mut self, block_offset: usize, data: &[u8]);
     fn image_fn(&self) -> Option<&Path>;
     fn load_media(&mut self, path: &Path) -> Result<()>;
@@ -197,7 +197,7 @@ pub(crate) trait ScsiTarget: Send + Debuggable {
                     log::error!("Reading beyond disk");
                     Ok(ScsiCmdResult::Status(STATUS_CHECK_CONDITION))
                 } else {
-                    self.read(blocknum, blockcnt).map(ScsiCmdResult::DataIn)
+                    self.read(blocknum, blockcnt)
                 }
             }
             0x0A => {
@@ -421,7 +421,7 @@ pub(crate) trait ScsiTarget: Send + Debuggable {
                     log::error!("Reading beyond disk");
                     Ok(ScsiCmdResult::Status(STATUS_CHECK_CONDITION))
                 } else {
-                    self.read(blocknum, blockcnt).map(ScsiCmdResult::DataIn)
+                    self.read(blocknum, blockcnt)
                 }
             }
             0x2A => {

--- a/core/src/mac/scsi/target.rs
+++ b/core/src/mac/scsi/target.rs
@@ -164,10 +164,21 @@ pub(crate) trait ScsiTarget: Send + Debuggable {
             }
             0x03 => {
                 // REQUEST SENSE
+                let alloc_len = cmd[4];
+
                 let (key, asc) = self.common().req_sense();
-                let mut result = vec![0; 14];
+                let mut result = vec![0; 18];
+                if key != 0 {
+                    // [SPC-3] 4.5.4: Current errors
+                    // Response codes 70h and 72h (current error) indicate that the sense data returned is the result of an error or
+                    // exception condition on the task that returned the CHECK CONDITION status or a protocol specific failure
+                    // condition.
+                    result[0] = 0x70; // Current error
+                }
                 result[2] = key & 0x0F;
                 result[12..14].copy_from_slice(&asc.to_be_bytes());
+
+                result.truncate(alloc_len as usize);
                 Ok(ScsiCmdResult::DataIn(result))
             }
             0x04 => {


### PR DESCRIPTION
This PR adds support for multi-session CD's.

- bin/cue parser now parses the REM LEAD-OUT and REM SESSION commands
- Mode 2 sectors can now be read via `read_bytes`
- Mac OS can now mount the bonus content track on Enhanced CD's
- Lengthy pauses when using Apple CD Extension 5.3.1 or later have been fixed (caused by unhandled commands)

No ugly workarounds needed!