### PR TITLE
Fix CD-ROM failing to detect on System 7.5 with Apple CD Extension 5.0.1

### DIFF
--- a/core/src/mac/scsi/cdrom/mod.rs
+++ b/core/src/mac/scsi/cdrom/mod.rs
@@ -15,7 +15,7 @@ use crate::mac::scsi::cdrom::backends::iso::IsoCdromBackend;
 use crate::mac::scsi::target::ScsiTargetCommon;
 use crate::mac::scsi::{
     ASC_ILLEGAL_MODE_FOR_THIS_TRACK, ASC_INVALID_COMMAND, ASC_LOGICAL_BLOCK_ADDRESS_OUT_OF_RANGE,
-    ASC_UNRECOVERED_READ_ERROR,
+    ASC_UNRECOVERED_READ_ERROR, CC_KEY_NOT_READY,
 };
 use crate::renderer::{AUDIO_BUFFER_SAMPLES, AudioProvider, AudioSink};
 use crate::tickable::Ticks;
@@ -286,8 +286,7 @@ impl ScsiTargetCdrom {
     ) -> Result<ScsiCmdResult> {
         let Some(backend) = &self.backend else {
             // No CD inserted
-            self.common
-                .set_cc(CC_KEY_MEDIUM_ERROR, ASC_MEDIUM_NOT_PRESENT);
+            self.common.set_cc(CC_KEY_NOT_READY, ASC_MEDIUM_NOT_PRESENT);
             return Ok(ScsiCmdResult::Status(STATUS_CHECK_CONDITION));
         };
 
@@ -700,13 +699,27 @@ impl ScsiTarget for ScsiTargetCdrom {
             Ok(ScsiCmdResult::Status(STATUS_GOOD))
         } else {
             // No CD inserted
-            self.common
-                .set_cc(CC_KEY_MEDIUM_ERROR, ASC_MEDIUM_NOT_PRESENT);
+            self.common.set_cc(CC_KEY_NOT_READY, ASC_MEDIUM_NOT_PRESENT);
             Ok(ScsiCmdResult::Status(STATUS_CHECK_CONDITION))
         }
     }
 
     fn inquiry(&mut self, cmd: &[u8]) -> Result<ScsiCmdResult> {
+        let evpd = cmd[1] & 0x1;
+        let page = cmd[2];
+        if evpd != 0 || page != 0 {
+            // [SPC-3] 6.4.1:
+            // If the PAGE CODE
+            // field is not set to zero when the EVPD bit is set to zero, the command shall be terminated with CHECK CONDITION
+            // status, with the sense key set to ILLEGAL REQUEST, and the additional sense code set to INVALID FIELD IN
+            // CDB.
+            self.common
+                .set_cc(CC_KEY_ILLEGAL_REQUEST, ASC_INVALID_FIELD_IN_CDB);
+            return Ok(ScsiCmdResult::Status(STATUS_CHECK_CONDITION));
+        }
+
+        let alloc_len = u16::from_be_bytes(cmd[3..=4].try_into().unwrap());
+
         let mut result = vec![0; 36];
 
         // 0 Peripheral qualifier (5-7), peripheral device type (4-0)
@@ -722,15 +735,11 @@ impl ScsiTarget for ScsiTargetCdrom {
         result[8..16].copy_from_slice(b"SNOW    ");
 
         // 16..32 Product identification
-        result[16..32].copy_from_slice(b"CD-ROM CDU-55S  ");
+        result[16..32].copy_from_slice(b"CD-ROM CDU-8004 ");
         // 32..36 Revision
         result[32..36].copy_from_slice(b"1.9a");
 
-        // Honour the initiator's allocation length (cmd[4] for 6-byte INQUIRY).
-        let alloc = cmd.get(4).copied().unwrap_or(0) as usize;
-        if alloc > 0 && alloc < result.len() {
-            result.truncate(alloc);
-        }
+        result.truncate(alloc_len as usize);
         Ok(ScsiCmdResult::DataIn(result))
     }
 
@@ -786,10 +795,19 @@ impl ScsiTarget for ScsiTargetCdrom {
                 Some(data)
             }
             0x30 => {
-                // ? Non-standard mode page
+                // Magic Apple page
 
                 let mut result = vec![0; 0x16];
                 result[0..0x16].copy_from_slice(b"APPLE COMPUTER, INC   ");
+                Some(result)
+            }
+            0x31 => {
+                // Magic BlueSCSI page
+
+                // Mac OS queries this page occasionally...
+                // this is what MAME returns. I don't know what the original drives returned.
+                let mut result = vec![0; 0x2a];
+                result[0..0x2a].copy_from_slice(b"BlueSCSI is the BEST STOLEN FROM BLUESCSI\0");
                 Some(result)
             }
             _ => None,
@@ -896,8 +914,7 @@ impl ScsiTarget for ScsiTargetCdrom {
             }
             // READ(6) (no media)
             0x08 => {
-                self.common
-                    .set_cc(CC_KEY_MEDIUM_ERROR, ASC_MEDIUM_NOT_PRESENT);
+                self.common.set_cc(CC_KEY_NOT_READY, ASC_MEDIUM_NOT_PRESENT);
                 Ok(ScsiCmdResult::Status(STATUS_CHECK_CONDITION))
             }
             // START/STOP UNIT
@@ -960,8 +977,7 @@ impl ScsiTarget for ScsiTargetCdrom {
                         let Some(track) = self.get_track_at_sector(self.audio_pos) else {
                             // No tracks available
                             // FIXME: is this correct?
-                            self.common
-                                .set_cc(CC_KEY_MEDIUM_ERROR, ASC_MEDIUM_NOT_PRESENT);
+                            self.common.set_cc(CC_KEY_NOT_READY, ASC_MEDIUM_NOT_PRESENT);
                             return Ok(ScsiCmdResult::Status(STATUS_CHECK_CONDITION));
                         };
 
@@ -1056,14 +1072,12 @@ impl ScsiTarget for ScsiTargetCdrom {
                 log::debug!("PLAY AUDIO MSF start {} end {}", start_msf, end_msf);
 
                 let Some(backend) = &self.backend else {
-                    self.common
-                        .set_cc(CC_KEY_MEDIUM_ERROR, ASC_MEDIUM_NOT_PRESENT);
+                    self.common.set_cc(CC_KEY_NOT_READY, ASC_MEDIUM_NOT_PRESENT);
                     return Ok(ScsiCmdResult::Status(STATUS_CHECK_CONDITION));
                 };
 
                 let Some(sessions) = backend.sessions() else {
-                    self.common
-                        .set_cc(CC_KEY_MEDIUM_ERROR, ASC_MEDIUM_NOT_PRESENT);
+                    self.common.set_cc(CC_KEY_NOT_READY, ASC_MEDIUM_NOT_PRESENT);
                     return Ok(ScsiCmdResult::Status(STATUS_CHECK_CONDITION));
                 };
 
@@ -1164,14 +1178,12 @@ impl ScsiTarget for ScsiTargetCdrom {
                 // Also known as fast-forward or rewind.
 
                 let Some(backend) = &self.backend else {
-                    self.common
-                        .set_cc(CC_KEY_MEDIUM_ERROR, ASC_MEDIUM_NOT_PRESENT);
+                    self.common.set_cc(CC_KEY_NOT_READY, ASC_MEDIUM_NOT_PRESENT);
                     return Ok(ScsiCmdResult::Status(STATUS_CHECK_CONDITION));
                 };
 
                 let Some(tracks) = backend.tracks() else {
-                    self.common
-                        .set_cc(CC_KEY_MEDIUM_ERROR, ASC_MEDIUM_NOT_PRESENT);
+                    self.common.set_cc(CC_KEY_NOT_READY, ASC_MEDIUM_NOT_PRESENT);
                     return Ok(ScsiCmdResult::Status(STATUS_CHECK_CONDITION));
                 };
 

--- a/core/src/mac/scsi/mod.rs
+++ b/core/src/mac/scsi/mod.rs
@@ -14,6 +14,7 @@ pub mod toolbox;
 pub const STATUS_GOOD: u8 = 0;
 pub const STATUS_CHECK_CONDITION: u8 = 2;
 
+pub const CC_KEY_NOT_READY: u8 = 0x02;
 pub const CC_KEY_MEDIUM_ERROR: u8 = 0x03;
 pub const CC_KEY_ILLEGAL_REQUEST: u8 = 0x05;
 

--- a/core/src/mac/scsi/target.rs
+++ b/core/src/mac/scsi/target.rs
@@ -10,7 +10,7 @@ use crate::emulator::EmuContext;
 use crate::mac::scsi::disk_image::DiskImage;
 use crate::mac::scsi::{
     ASC_INVALID_FIELD_IN_CDB, ASC_LOGICAL_BLOCK_ADDRESS_OUT_OF_RANGE, ASC_MEDIUM_NOT_PRESENT,
-    ASC_PARAMETER_LIST_LENGTH_ERROR, CC_KEY_ILLEGAL_REQUEST, CC_KEY_MEDIUM_ERROR,
+    ASC_PARAMETER_LIST_LENGTH_ERROR, CC_KEY_ILLEGAL_REQUEST, CC_KEY_NOT_READY,
     STATUS_CHECK_CONDITION, STATUS_GOOD, ScsiCmdResult,
 };
 use crate::renderer::AudioProvider;
@@ -199,6 +199,10 @@ pub(crate) trait ScsiTarget: Send + Debuggable {
 
                 if blocknum + blockcnt > blocks {
                     log::error!("Reading beyond disk");
+                    self.common().set_cc(
+                        CC_KEY_ILLEGAL_REQUEST,
+                        ASC_LOGICAL_BLOCK_ADDRESS_OUT_OF_RANGE,
+                    );
                     Ok(ScsiCmdResult::Status(STATUS_CHECK_CONDITION))
                 } else {
                     self.read(blocknum, blockcnt)
@@ -215,6 +219,10 @@ pub(crate) trait ScsiTarget: Send + Debuggable {
                 if let Some(data) = outdata {
                     if blocknum + blockcnt > blocks {
                         log::error!("Writing beyond disk");
+                        self.common().set_cc(
+                            CC_KEY_ILLEGAL_REQUEST,
+                            ASC_LOGICAL_BLOCK_ADDRESS_OUT_OF_RANGE,
+                        );
                         Ok(ScsiCmdResult::Status(STATUS_CHECK_CONDITION))
                     } else {
                         self.write(blocknum, data);
@@ -233,6 +241,10 @@ pub(crate) trait ScsiTarget: Send + Debuggable {
                 if self.check_lba_within_capacity(lba) {
                     Ok(ScsiCmdResult::Status(STATUS_GOOD))
                 } else {
+                    self.common().set_cc(
+                        CC_KEY_ILLEGAL_REQUEST,
+                        ASC_LOGICAL_BLOCK_ADDRESS_OUT_OF_RANGE,
+                    );
                     Ok(ScsiCmdResult::Status(STATUS_CHECK_CONDITION))
                 }
             }
@@ -402,7 +414,7 @@ pub(crate) trait ScsiTarget: Send + Debuggable {
                 let (Some(blocksize), Some(blocks)) = (self.blocksize(), self.blocks()) else {
                     log::warn!("READ CAPACITY(10) command to non-block device");
                     self.common()
-                        .set_cc(CC_KEY_MEDIUM_ERROR, ASC_MEDIUM_NOT_PRESENT);
+                        .set_cc(CC_KEY_NOT_READY, ASC_MEDIUM_NOT_PRESENT);
                     return Ok(ScsiCmdResult::Status(STATUS_CHECK_CONDITION));
                 };
 
@@ -415,7 +427,7 @@ pub(crate) trait ScsiTarget: Send + Debuggable {
                 let Some(blocks) = self.blocks() else {
                     log::warn!("READ(10) command to non-block device");
                     self.common()
-                        .set_cc(CC_KEY_MEDIUM_ERROR, ASC_MEDIUM_NOT_PRESENT);
+                        .set_cc(CC_KEY_NOT_READY, ASC_MEDIUM_NOT_PRESENT);
                     return Ok(ScsiCmdResult::Status(STATUS_CHECK_CONDITION));
                 };
                 let blocknum = (u32::from_be_bytes(cmd[2..6].try_into()?)) as usize;
@@ -423,6 +435,10 @@ pub(crate) trait ScsiTarget: Send + Debuggable {
 
                 if blocknum + blockcnt > blocks {
                     log::error!("Reading beyond disk");
+                    self.common().set_cc(
+                        CC_KEY_ILLEGAL_REQUEST,
+                        ASC_LOGICAL_BLOCK_ADDRESS_OUT_OF_RANGE,
+                    );
                     Ok(ScsiCmdResult::Status(STATUS_CHECK_CONDITION))
                 } else {
                     self.read(blocknum, blockcnt)
@@ -433,7 +449,7 @@ pub(crate) trait ScsiTarget: Send + Debuggable {
                 let (Some(blocksize), Some(blocks)) = (self.blocksize(), self.blocks()) else {
                     log::warn!("WRITE(10) command to non-block device");
                     self.common()
-                        .set_cc(CC_KEY_MEDIUM_ERROR, ASC_MEDIUM_NOT_PRESENT);
+                        .set_cc(CC_KEY_NOT_READY, ASC_MEDIUM_NOT_PRESENT);
                     return Ok(ScsiCmdResult::Status(STATUS_CHECK_CONDITION));
                 };
                 let blocknum = (u32::from_be_bytes(cmd[2..6].try_into()?)) as usize;
@@ -442,6 +458,10 @@ pub(crate) trait ScsiTarget: Send + Debuggable {
                 if let Some(data) = outdata {
                     if blocknum + blockcnt > blocks {
                         log::error!("Writing beyond disk");
+                        self.common().set_cc(
+                            CC_KEY_ILLEGAL_REQUEST,
+                            ASC_LOGICAL_BLOCK_ADDRESS_OUT_OF_RANGE,
+                        );
                         Ok(ScsiCmdResult::Status(STATUS_CHECK_CONDITION))
                     } else {
                         self.write(blocknum, data);


### PR DESCRIPTION
Fixes issue #300 .

- CD-ROM drive is now reported as a CD-ROM CDU-8004 (one of the models supported by Apple CD Extension 5.0.1)
- MEDIUM ERROR must use a NOT READY sense key - fixes startup crash

Known issues:

- Enhanced CD's will fail to play on Apple CD Extension 5.0.1. However, normal Audio CD's and Data CD's work fine. Enhanced CD's work on Apple CD Extension 5.3.1 or later.