### PR TITLE
printer: fix image relative path in docs

### DIFF
--- a/docs/src/manual/printing.md
+++ b/docs/src/manual/printing.md
@@ -22,7 +22,7 @@ According to KB030514, Apple deprecated the driver starting System 7.5.1. Althou
 
 To select the printer, just choose the printer in the chooser. It will not display anything in the list like you would normally expect.
 
-![LaserWriter in Chooser](../../images/printer_chooser.png)
+![LaserWriter in Chooser](../images/printer_chooser.png)
 
 The driver will scan the SCSI bus every time you print something (scan order: 4, 3, 2, 1, 0, 6, 5).
 


### PR DESCRIPTION
Made a mistake yesterday, this is the fix.

For some reason "mdbook serve -o" managed to display the image with the wrong path depth