### PR TITLE
Freebsd

### DIFF
--- a/docs/src/getting_started/building.md
+++ b/docs/src/getting_started/building.md
@@ -15,7 +15,7 @@ sudo apt install libasound2-dev pkg-config
 On FreeBSD you need the ALSA compatibility library
 
 ```shell
-sudo pkg install alsa-lib
+sudo pkg install alsa-lib pkgconf
 ```
 
 ## Building and running from source

--- a/docs/src/getting_started/building.md
+++ b/docs/src/getting_started/building.md
@@ -12,6 +12,12 @@ On Linux you need the ALSA development headers; on Debian or Ubuntu:
 sudo apt install libasound2-dev pkg-config
 ```
 
+On FreeBSD you need the ALSA compatibility library
+
+```shell
+sudo pkg install alsa-lib
+```
+
 ## Building and running from source
 
 To build and run the GUI after checking out the source, simply run:


### PR DESCRIPTION
This fixes #307.

This matches the Linux behaviour, so just add some Documentation. The idea is to use ALSA emulation under FreeBSD for now. This allows cpal to build just fine.

It can be removed later if cpal implements an OSS backend. Users have the choice to run the old SDL2 layer as well.
