### PR TITLE
Improvements with smoltcp & NAT gateway

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2394,9 +2394,9 @@ dependencies = [
 
 [[package]]
 name = "heapless"
-version = "0.8.0"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
+checksum = "25ba4bd83f9415b58b4ed8dc5714c76e626a105be4646c02630ad730ad3b5aa4"
 dependencies = [
  "hash32 0.3.1",
  "stable_deref_trait",
@@ -4915,15 +4915,15 @@ dependencies = [
 
 [[package]]
 name = "smoltcp"
-version = "0.12.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dad095989c1533c1c266d9b1e8d70a1329dd3723c3edac6d03bbd67e7bf6f4bb"
+checksum = "5f73d40463bba65efc9adc6370b56df76d563cc46e2482bba58351b4afb7535e"
 dependencies = [
  "bitflags 1.3.2",
  "byteorder",
  "cfg-if",
  "defmt 0.3.100",
- "heapless 0.8.0",
+ "heapless 0.9.3",
  "libc",
  "log",
  "managed",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4915,9 +4915,9 @@ dependencies = [
 
 [[package]]
 name = "smoltcp"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a1a996951e50b5971a2c8c0fa05a381480d70a933064245c4a223ddc87ccc97"
+checksum = "dad095989c1533c1c266d9b1e8d70a1329dd3723c3edac6d03bbd67e7bf6f4bb"
 dependencies = [
  "bitflags 1.3.2",
  "byteorder",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4924,7 +4924,6 @@ dependencies = [
  "cfg-if",
  "defmt 0.3.100",
  "heapless 0.9.3",
- "libc",
  "log",
  "managed",
 ]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -16,6 +16,8 @@ ethernet_raw = ["ethernet", "dep:pnet"]
 ethernet_nat = ["ethernet", "dep:snow_nat"]
 # Enables HTTPS stripping proxy in NAT
 ethernet_nat_https_stripping = ["ethernet_nat", "snow_nat/https_stripping"]
+# Enables MacTCP helpers in NAT (ICMP, RARP server)
+ethernet_nat_mactcp_helpers = ["ethernet_nat", "snow_nat/mactcp_helpers"]
 # Enables Ethernet bridging via TAP interface (Linux only)
 ethernet_tap = ["ethernet", "dep:tun", "nix/poll", "dep:pnet"]
 # Enables Apple LaserWriter IISC SCSI printer emulation

--- a/core/src/mac/scsi/ethernet.rs
+++ b/core/src/mac/scsi/ethernet.rs
@@ -37,6 +37,10 @@ type BasicPacket = Vec<u8>;
 /// Maximum amount of packets to buffer in the RX/TX queues
 const PACKET_QUEUE_SIZE: usize = 512;
 
+/// Locally administered MAC address of the NAT gateway visible from the emulated Mac.
+#[cfg(feature = "ethernet_nat")]
+const NAT_MAC_ADDRESS: [u8; 6] = [0xAA, 0x55, 0xAA, 0x55, 0xAA, 0x55];
+
 /// Pcap file header structure
 /// https://wiki.wireshark.org/Development/LibpcapFileFormat
 /// https://www.winpcap.org/docs/docs_412/html/structpcap__file__header.html
@@ -1001,7 +1005,7 @@ impl ScsiTarget for ScsiTargetEthernet {
                 let mut nat = snow_nat::NatEngine::new(
                     nat_tx,
                     nat_rx,
-                    [0x55, 0xAA, 0x55, 0xAA, 0x55, 0xAA],
+                    NAT_MAC_ADDRESS,
                     [10, 0, 0, 1],
                     8,
                     #[cfg(feature = "ethernet_nat_https_stripping")]
@@ -1022,7 +1026,7 @@ impl ScsiTarget for ScsiTargetEthernet {
                 let mut nat = snow_nat::NatEngine::new(
                     nat_tx,
                     nat_rx,
-                    [0x55, 0xAA, 0x55, 0xAA, 0x55, 0xAA],
+                    NAT_MAC_ADDRESS,
                     [10, 0, 0, 1],
                     8,
                     true, // Enable HTTPS stripping

--- a/core/src/mac/scsi/ethernet.rs
+++ b/core/src/mac/scsi/ethernet.rs
@@ -1123,6 +1123,14 @@ impl Debuggable for ScsiTargetEthernet {
                         stats.tx_bytes.load(Ordering::Relaxed)
                     ),
                     dbgprop_udec!(
+                        "Filtered packets",
+                        stats.filtered_packets.load(Ordering::Relaxed)
+                    ),
+                    dbgprop_udec!(
+                        "Filtered bytes",
+                        stats.filtered_bytes.load(Ordering::Relaxed)
+                    ),
+                    dbgprop_udec!(
                         "Active TCP connections",
                         stats.nat_active_tcp.load(Ordering::Relaxed)
                     ),

--- a/frontend_egui/Cargo.toml
+++ b/frontend_egui/Cargo.toml
@@ -9,10 +9,11 @@ name = "snowemu"
 path = "src/main.rs"
 
 [features]
-default = ["ethernet", "ethernet_nat", "ethernet_nat_https_stripping", "ethernet_tap", "printer"]
+default = ["ethernet", "ethernet_nat", "ethernet_nat_https_stripping", "ethernet_nat_mactcp_helpers", "ethernet_tap", "printer"]
 ethernet = ["snow_core/ethernet"]
 ethernet_nat = ["ethernet", "snow_core/ethernet_nat"]
 ethernet_nat_https_stripping = ["ethernet_nat", "snow_core/ethernet_nat_https_stripping"]
+ethernet_nat_mactcp_helpers = ["ethernet_nat", "snow_core/ethernet_nat_mactcp_helpers"]
 ethernet_raw = ["ethernet", "snow_core/ethernet_raw", "dep:pnet"]
 ethernet_tap = ["ethernet", "snow_core/ethernet_tap", "dep:pnet"]
 printer = ["snow_core/printer"]

--- a/nat/Cargo.toml
+++ b/nat/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2024"
 
 [features]
 https_stripping = ["dep:rustls", "dep:rustls-native-certs", "dep:rustls-pki-types"]
+mactcp_helpers = []
 
 [dependencies]
 smoltcp = "0.13.1"

--- a/nat/Cargo.toml
+++ b/nat/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2024"
 https_stripping = ["dep:rustls", "dep:rustls-native-certs", "dep:rustls-pki-types"]
 
 [dependencies]
-smoltcp = "0.11"
+smoltcp = "0.12"
 crossbeam-channel = "0.5"
 log = "0.4"
 anyhow = "1.0"

--- a/nat/Cargo.toml
+++ b/nat/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2024"
 https_stripping = ["dep:rustls", "dep:rustls-native-certs", "dep:rustls-pki-types"]
 
 [dependencies]
-smoltcp = "0.12"
+smoltcp = "0.13.1"
 crossbeam-channel = "0.5"
 log = "0.4"
 anyhow = "1.0"

--- a/nat/Cargo.toml
+++ b/nat/Cargo.toml
@@ -8,7 +8,7 @@ https_stripping = ["dep:rustls", "dep:rustls-native-certs", "dep:rustls-pki-type
 mactcp_helpers = []
 
 [dependencies]
-smoltcp = { version = "0.13.1", default-features = false, features = [ "std", "log", "medium-ethernet", "proto-ipv4", "socket-udp", "socket-tcp", "socket-tcp-reno", ] }
+smoltcp = { version = "0.13.1", default-features = false, features = [ "std", "log", "medium-ethernet", "proto-ipv4", "auto-icmp-echo-reply", "socket-udp", "socket-tcp", "socket-tcp-reno", ] }
 crossbeam-channel = "0.5"
 log = "0.4"
 anyhow = "1.0"

--- a/nat/Cargo.toml
+++ b/nat/Cargo.toml
@@ -8,7 +8,7 @@ https_stripping = ["dep:rustls", "dep:rustls-native-certs", "dep:rustls-pki-type
 mactcp_helpers = []
 
 [dependencies]
-smoltcp = "0.13.1"
+smoltcp = { version = "0.13.1", default-features = false, features = [ "std", "log", "medium-ethernet", "proto-ipv4", "socket-udp", "socket-tcp", "socket-tcp-reno", ] }
 crossbeam-channel = "0.5"
 log = "0.4"
 anyhow = "1.0"

--- a/nat/src/lib.rs
+++ b/nat/src/lib.rs
@@ -17,6 +17,9 @@
 #[cfg(feature = "https_stripping")]
 mod https_stripping;
 
+#[cfg(feature = "mactcp_helpers")]
+mod mactcp_helpers;
+
 use std::collections::HashMap;
 use std::io::{Read, Write};
 use std::net::{SocketAddr, TcpStream, UdpSocket};
@@ -136,6 +139,12 @@ impl VirtualDevice {
             Ok(frame) => frame,
             Err(_) => return false,
         };
+
+        // Intercept RARP broadcasts so handle_rarp() can reply locally
+        #[cfg(feature = "mactcp_helpers")]
+        if eth_frame.ethertype() == EthernetProtocol::Unknown(0x8035) {
+            return true;
+        }
 
         // Check if it's IPv4
         if eth_frame.ethertype() != EthernetProtocol::Ipv4 {
@@ -629,6 +638,14 @@ impl NatEngine {
                 }
             };
 
+            #[cfg(feature = "mactcp_helpers")]
+            if eth_frame.ethertype() == EthernetProtocol::Unknown(0x8035) {
+                if let Err(e) = self.handle_rarp(&eth_frame) {
+                    log::error!("Failed to handle RARP: {}", e);
+                }
+                continue;
+            }
+
             let ipv4_packet = match Ipv4Packet::new_checked(eth_frame.payload()) {
                 Ok(packet) => packet,
                 Err(e) => {
@@ -671,6 +688,33 @@ impl NatEngine {
                     log::warn!("Unsupported protocol: {:?}", ipv4_packet.next_header());
                 }
             }
+        }
+
+        Ok(())
+    }
+
+    /// Handle a RARP request by replying with the assigned IP for the client MAC
+    #[cfg(feature = "mactcp_helpers")]
+    fn handle_rarp(&mut self, eth_frame: &smoltcp::wire::EthernetFrame<&[u8]>) -> Result<()> {
+        let gw_ipv4 = match self.gateway_ip {
+            IpAddress::Ipv4(a) => a,
+            _ => return Ok(()),
+        };
+
+        let Some(buf) = mactcp_helpers::handle_rarp_request(eth_frame, gw_ipv4, self.gateway_mac)?
+        else {
+            return Ok(());
+        };
+
+        match self.device.tx.try_send(buf) {
+            Ok(()) => {
+                self.stats.tx_packets.fetch_add(1, Ordering::Relaxed);
+                self.stats.tx_bytes.fetch_add(42, Ordering::Relaxed);
+            }
+            Err(TrySendError::Full(_)) => {
+                self.stats.tx_dropped.fetch_add(1, Ordering::Relaxed);
+            }
+            Err(TrySendError::Disconnected(_)) => {}
         }
 
         Ok(())

--- a/nat/src/lib.rs
+++ b/nat/src/lib.rs
@@ -695,7 +695,7 @@ impl NatEngine {
 
     /// Handle a RARP request by replying with the assigned IP for the client MAC
     #[cfg(feature = "mactcp_helpers")]
-    fn handle_rarp(&mut self, eth_frame: &smoltcp::wire::EthernetFrame<&[u8]>) -> Result<()> {
+    fn handle_rarp(&self, eth_frame: &smoltcp::wire::EthernetFrame<&[u8]>) -> Result<()> {
         let gw_ipv4 = match self.gateway_ip {
             IpAddress::Ipv4(a) => a,
             _ => return Ok(()),

--- a/nat/src/lib.rs
+++ b/nat/src/lib.rs
@@ -270,11 +270,11 @@ struct VirtualRxToken {
 }
 
 impl RxToken for VirtualRxToken {
-    fn consume<R, F>(mut self, f: F) -> R
+    fn consume<R, F>(self, f: F) -> R
     where
-        F: FnOnce(&mut [u8]) -> R,
+        F: FnOnce(&[u8]) -> R,
     {
-        f(&mut self.buffer)
+        f(&self.buffer)
     }
 }
 
@@ -447,7 +447,7 @@ impl NatEngine {
         let gateway_ip_addr =
             IpAddress::v4(gateway_ip[0], gateway_ip[1], gateway_ip[2], gateway_ip[3]);
 
-        let gateway_ipv4 = Ipv4Address::from_bytes(&gateway_ip);
+        let gateway_ipv4 = Ipv4Address::from(gateway_ip);
         let mut device = VirtualDevice::new(tx, rx, stats.clone(), gateway_ipv4);
 
         let config = Config::new(gateway_mac_addr.into());
@@ -664,7 +664,7 @@ impl NatEngine {
             os_socket.set_nonblocking(true)?;
 
             let remote_addr = SocketAddr::new(
-                std::net::IpAddr::V4(std::net::Ipv4Addr::from(dst_ip.0)),
+                std::net::IpAddr::V4(dst_ip),
                 dst_port,
             );
             os_socket.connect(remote_addr)?;
@@ -824,7 +824,7 @@ impl NatEngine {
         } else {
             // Normal TCP connection
             let remote_addr = SocketAddr::new(
-                std::net::IpAddr::V4(std::net::Ipv4Addr::from(dst_ip.0)),
+                std::net::IpAddr::V4(dst_ip),
                 dst_port,
             );
 
@@ -979,7 +979,7 @@ impl NatEngine {
                                 // Establish TLS connection using the hostname for SNI
                                 let dst_ip_addr = match entry.remote_endpoint.addr {
                                     IpAddress::Ipv4(ip) => {
-                                        std::net::IpAddr::V4(std::net::Ipv4Addr::from(ip.0))
+                                        std::net::IpAddr::V4(ip)
                                     }
                                     _ => {
                                         log::error!("Non-IPv4 address in HTTPS stripping");

--- a/nat/src/lib.rs
+++ b/nat/src/lib.rs
@@ -258,6 +258,13 @@ impl Device for VirtualDevice {
             return None;
         }
 
+        // Intercept ICMP packets MacTCP Helpers can handle instead of smoltcp
+        #[cfg(feature = "mactcp_helpers")]
+        if mactcp_helpers::needs_icmp_proxy(&packet) {
+            self.intercepted_packets.push(packet);
+            return None;
+        }
+
         // Check if this packet needs NAT (routed TCP/UDP)
         if self.needs_nat(&packet) {
             self.intercepted_packets.push(packet);
@@ -496,6 +503,10 @@ pub struct NatEngine {
     /// Whether to enable HTTPS stripping
     #[cfg(feature = "https_stripping")]
     https_stripping: bool,
+
+    /// Gateway subnet prefix length (for ICMP Address Mask replies)
+    #[cfg(feature = "mactcp_helpers")]
+    gateway_subnet: u8,
 }
 
 impl NatEngine {
@@ -559,6 +570,8 @@ impl NatEngine {
             stats,
             #[cfg(feature = "https_stripping")]
             https_stripping,
+            #[cfg(feature = "mactcp_helpers")]
+            gateway_subnet,
         }
     }
 
@@ -686,6 +699,25 @@ impl NatEngine {
                         self.handle_outbound_tcp(&packet[..], &eth_frame, &ipv4_packet, &tcp_packet)
                     {
                         log::error!("Failed to handle outbound TCP: {}", e);
+                    }
+                }
+                #[cfg(feature = "mactcp_helpers")]
+                IpProtocol::Icmp => {
+                    let gw_ipv4 = match self.gateway_ip {
+                        IpAddress::Ipv4(a) => a,
+                        _ => continue,
+                    };
+                    match mactcp_helpers::handle_icmp_address_mask_request(
+                        &eth_frame,
+                        gw_ipv4,
+                        self.gateway_mac,
+                        self.gateway_subnet,
+                    ) {
+                        Ok(Some(buf)) => {
+                            self.device.tx.try_send(buf).ok();
+                        }
+                        Ok(None) => {}
+                        Err(e) => log::error!("Failed to handle ICMP address mask: {}", e),
                     }
                 }
                 _ => {

--- a/nat/src/lib.rs
+++ b/nat/src/lib.rs
@@ -127,7 +127,13 @@ impl VirtualDevice {
             Err(_) => return false,
         };
 
-        ipv4_packet.src_addr() == Ipv4Address::new(0, 0, 0, 0) || udp_packet.src_port() < 1024
+        if ipv4_packet.dst_addr() == Ipv4Address::BROADCAST {
+            return true;
+        }
+
+        ipv4_packet.src_addr() == Ipv4Address::new(0, 0, 0, 0)
+            || udp_packet.src_port() < 1024
+            || udp_packet.dst_port() == 520
     }
 
     /// Check if a packet needs NAT (routed UDP or TCP SYN packet where destination IP != gateway IP)

--- a/nat/src/lib.rs
+++ b/nat/src/lib.rs
@@ -663,10 +663,7 @@ impl NatEngine {
             let os_socket = UdpSocket::bind("0.0.0.0:0")?;
             os_socket.set_nonblocking(true)?;
 
-            let remote_addr = SocketAddr::new(
-                std::net::IpAddr::V4(dst_ip),
-                dst_port,
-            );
+            let remote_addr = SocketAddr::new(std::net::IpAddr::V4(dst_ip), dst_port);
             os_socket.connect(remote_addr)?;
             os_socket.send(payload)?;
 
@@ -823,10 +820,7 @@ impl NatEngine {
             unreachable!()
         } else {
             // Normal TCP connection
-            let remote_addr = SocketAddr::new(
-                std::net::IpAddr::V4(dst_ip),
-                dst_port,
-            );
+            let remote_addr = SocketAddr::new(std::net::IpAddr::V4(dst_ip), dst_port);
 
             let os_socket = TcpStream::connect_timeout(&remote_addr, Duration::from_secs(5))?;
             os_socket.set_nonblocking(true)?;
@@ -978,9 +972,7 @@ impl NatEngine {
 
                                 // Establish TLS connection using the hostname for SNI
                                 let dst_ip_addr = match entry.remote_endpoint.addr {
-                                    IpAddress::Ipv4(ip) => {
-                                        std::net::IpAddr::V4(ip)
-                                    }
+                                    IpAddress::Ipv4(ip) => std::net::IpAddr::V4(ip),
                                     _ => {
                                         log::error!("Non-IPv4 address in HTTPS stripping");
                                         tls_failed = true;

--- a/nat/src/lib.rs
+++ b/nat/src/lib.rs
@@ -980,7 +980,32 @@ impl NatEngine {
             // Normal TCP connection
             let remote_addr = SocketAddr::new(std::net::IpAddr::V4(dst_ip), dst_port);
 
-            let os_socket = TcpStream::connect_timeout(&remote_addr, Duration::from_secs(5))?;
+            let os_socket = match TcpStream::connect_timeout(&remote_addr, Duration::from_secs(5)) {
+                Ok(s) => s,
+                #[cfg(feature = "mactcp_helpers")]
+                Err(e) if e.kind() == std::io::ErrorKind::ConnectionRefused => {
+                    let ack_num = (tcp_packet.seq_number().0 as u32).wrapping_add(1);
+                    let buf = mactcp_helpers::build_tcp_rst(
+                        _eth_frame.src_addr(),
+                        self.gateway_mac,
+                        dst_ip,
+                        src_ip,
+                        dst_port,
+                        src_port,
+                        ack_num,
+                    );
+                    self.device.tx.try_send(buf).ok();
+                    log::debug!(
+                        "NAT: Sent TCP RST to {}:{} for {}:{}",
+                        src_ip,
+                        src_port,
+                        dst_ip,
+                        dst_port
+                    );
+                    return Ok(());
+                }
+                Err(e) => return Err(e.into()),
+            };
             os_socket.set_nonblocking(true)?;
 
             // Create smoltcp TCP socket for the emulator side

--- a/nat/src/lib.rs
+++ b/nat/src/lib.rs
@@ -100,7 +100,9 @@ impl VirtualDevice {
     /// Check for IPv4 packets that the NAT gateway should not handle.
     /// Filters UDP packets that would cause OS bind/connect errors:
     ///   - src IP 0.0.0.0 (mostly BOOTP requests for MacTCP)
-    ///   - src port < 1024 (privileged ports as the emulator is likely running as non-root)
+    ///   - broadcasts (255.255.255.255)
+    ///   - UDP src port < 1024 (privileged ports as the emulator is likely running as non-root)
+    ///   - UDP dst port == 520 (RIP)
     fn needs_filtering(&self, packet: &[u8]) -> bool {
         use smoltcp::wire::{IpProtocol, Ipv4Packet, UdpPacket};
 

--- a/nat/src/lib.rs
+++ b/nat/src/lib.rs
@@ -358,6 +358,10 @@ impl TxToken for VirtualTxToken {
         let mut buffer = vec![0u8; len];
         let result = f(&mut buffer);
 
+        // Throttle ICMP replies to avoid a race condition within MacTCP
+        #[cfg(feature = "mactcp_helpers")]
+        mactcp_helpers::delay_icmp_reply(&buffer);
+
         // Send the packet back to the emulator
         let send_len = buffer.len();
         match self.tx.try_send(buffer) {

--- a/nat/src/lib.rs
+++ b/nat/src/lib.rs
@@ -242,9 +242,7 @@ impl Device for VirtualDevice {
 
         // Drop packets that would cause OS errors (BOOTP, privileged src ports)
         if self.needs_filtering(&packet) {
-            self.stats
-                .filtered_packets
-                .fetch_add(1, Ordering::Relaxed);
+            self.stats.filtered_packets.fetch_add(1, Ordering::Relaxed);
             self.stats
                 .filtered_bytes
                 .fetch_add(packet.len(), Ordering::Relaxed);

--- a/nat/src/lib.rs
+++ b/nat/src/lib.rs
@@ -94,6 +94,39 @@ impl VirtualDevice {
         std::mem::take(&mut self.intercepted_packets)
     }
 
+    /// Check for IPv4 packets that the NAT gateway should not handle.
+    /// Filters UDP packets that would cause OS bind/connect errors:
+    ///   - src IP 0.0.0.0 (mostly BOOTP requests for MacTCP)
+    ///   - src port < 1024 (privileged ports as the emulator is likely running as non-root)
+    fn needs_filtering(&self, packet: &[u8]) -> bool {
+        use smoltcp::wire::{IpProtocol, Ipv4Packet, UdpPacket};
+
+        let eth_frame = match EthernetFrame::new_checked(packet) {
+            Ok(frame) => frame,
+            Err(_) => return false,
+        };
+
+        if eth_frame.ethertype() != EthernetProtocol::Ipv4 {
+            return false;
+        }
+
+        let ipv4_packet = match Ipv4Packet::new_checked(eth_frame.payload()) {
+            Ok(packet) => packet,
+            Err(_) => return false,
+        };
+
+        if ipv4_packet.next_header() != IpProtocol::Udp {
+            return false;
+        }
+
+        let udp_packet = match UdpPacket::new_checked(ipv4_packet.payload()) {
+            Ok(packet) => packet,
+            Err(_) => return false,
+        };
+
+        ipv4_packet.src_addr() == Ipv4Address::new(0, 0, 0, 0) || udp_packet.src_port() < 1024
+    }
+
     /// Check if a packet needs NAT (routed UDP or TCP SYN packet where destination IP != gateway IP)
     fn needs_nat(&self, packet: &[u8]) -> bool {
         use smoltcp::wire::{EthernetFrame, IpProtocol, Ipv4Packet, TcpPacket};
@@ -206,6 +239,17 @@ impl Device for VirtualDevice {
         self.stats
             .rx_bytes
             .fetch_add(packet.len(), Ordering::Relaxed);
+
+        // Drop packets that would cause OS errors (BOOTP, privileged src ports)
+        if self.needs_filtering(&packet) {
+            self.stats
+                .filtered_packets
+                .fetch_add(1, Ordering::Relaxed);
+            self.stats
+                .filtered_bytes
+                .fetch_add(packet.len(), Ordering::Relaxed);
+            return None;
+        }
 
         // Check if this packet needs NAT (routed TCP/UDP)
         if self.needs_nat(&packet) {
@@ -400,6 +444,8 @@ pub struct NatEngineStats {
     pub tx_packets: NatEngineStatCounter,
     pub tx_bytes: NatEngineStatCounter,
     pub tx_dropped: NatEngineStatCounter,
+    pub filtered_packets: NatEngineStatCounter,
+    pub filtered_bytes: NatEngineStatCounter,
     pub nat_active_tcp: NatEngineStatCounter,
     pub nat_total_tcp: NatEngineStatCounter,
     pub nat_active_udp: NatEngineStatCounter,

--- a/nat/src/lib.rs
+++ b/nat/src/lib.rs
@@ -240,6 +240,22 @@ impl Device for VirtualDevice {
             );
         }
 
+        // Drop ARP requests not targeting the NAT gateway
+        // This prevents smoltcp from replying to gratuitous ARPs or claiming ownership
+        // of other IP addresses. This happens because any_ip is enabled below
+        if let Ok(ArpRepr::EthernetIpv4 {
+            operation,
+            target_protocol_addr,
+            ..
+        }) = EthernetFrame::new_checked(&packet)
+            .and_then(|p| ArpPacket::new_checked(p.payload()))
+            .and_then(|p| ArpRepr::parse(&p))
+            && operation == ArpOperation::Request
+            && target_protocol_addr != self.gateway_ip
+        {
+            return None;
+        }
+
         // Pass non-routed packets (like ARP) normally
         Some((
             VirtualRxToken { buffer: packet },

--- a/nat/src/lib.rs
+++ b/nat/src/lib.rs
@@ -131,9 +131,21 @@ impl VirtualDevice {
             return true;
         }
 
-        ipv4_packet.src_addr() == Ipv4Address::new(0, 0, 0, 0)
+        let filtered = ipv4_packet.src_addr() == Ipv4Address::new(0, 0, 0, 0)
             || udp_packet.src_port() < 1024
-            || udp_packet.dst_port() == 520
+            || udp_packet.dst_port() == 520;
+
+        if filtered {
+            log::debug!(
+                "NAT: Filtered connection from {}:{} to {}:{}",
+                ipv4_packet.src_addr(),
+                udp_packet.src_port(),
+                ipv4_packet.dst_addr(),
+                udp_packet.dst_port()
+            );
+        }
+
+        filtered
     }
 
     /// Check if a packet needs NAT (routed UDP or TCP SYN packet where destination IP != gateway IP)

--- a/nat/src/lib.rs
+++ b/nat/src/lib.rs
@@ -838,8 +838,9 @@ impl NatEngine {
             );
             let mut socket = udp::Socket::new(rx_buffer, tx_buffer);
 
-            // Bind to gateway IP with the same source port the emulator used
-            let bind_endpoint = IpEndpoint::new(self.gateway_ip, src_port);
+            // Bind to remote endpoint so responses appear to come from the actual remote.
+            // TCP does a similar stuff. This works because any_ip is enabled.
+            let bind_endpoint = IpEndpoint::new(IpAddress::Ipv4(dst_ip), dst_port);
             socket.bind(bind_endpoint)?;
 
             let handle = self.sockets.add(socket);

--- a/nat/src/lib.rs
+++ b/nat/src/lib.rs
@@ -723,10 +723,7 @@ impl NatEngine {
                 }
                 #[cfg(feature = "mactcp_helpers")]
                 IpProtocol::Icmp => {
-                    let gw_ipv4 = match self.gateway_ip {
-                        IpAddress::Ipv4(a) => a,
-                        _ => continue,
-                    };
+                    let IpAddress::Ipv4(gw_ipv4) = self.gateway_ip;
                     match mactcp_helpers::handle_icmp_address_mask_request(
                         &eth_frame,
                         gw_ipv4,
@@ -752,10 +749,7 @@ impl NatEngine {
     /// Handle a RARP request by replying with the assigned IP for the client MAC
     #[cfg(feature = "mactcp_helpers")]
     fn handle_rarp(&self, eth_frame: &smoltcp::wire::EthernetFrame<&[u8]>) -> Result<()> {
-        let gw_ipv4 = match self.gateway_ip {
-            IpAddress::Ipv4(a) => a,
-            _ => return Ok(()),
-        };
+        let IpAddress::Ipv4(gw_ipv4) = self.gateway_ip;
 
         let Some(buf) = mactcp_helpers::handle_rarp_request(eth_frame, gw_ipv4, self.gateway_mac)?
         else {
@@ -791,18 +785,11 @@ impl NatEngine {
         // Check if we already have a NAT entry for this flow
         let existing_entry = self.nat_table.iter().find(|(_, entry)| {
             if let NatEntry::Udp(entry) = entry {
-                let mac_match = if let IpAddress::Ipv4(mac_ipv4) = entry.local_endpoint.addr {
-                    mac_ipv4 == src_ip && entry.local_endpoint.port == src_port
-                } else {
-                    false
-                };
+                let IpAddress::Ipv4(mac_ipv4) = entry.local_endpoint.addr;
+                let mac_match = mac_ipv4 == src_ip && entry.local_endpoint.port == src_port;
 
-                let remote_match = if let IpAddress::Ipv4(remote_ipv4) = entry.remote_endpoint.addr
-                {
-                    remote_ipv4 == dst_ip && entry.remote_endpoint.port == dst_port
-                } else {
-                    false
-                };
+                let IpAddress::Ipv4(remote_ipv4) = entry.remote_endpoint.addr;
+                let remote_match = remote_ipv4 == dst_ip && entry.remote_endpoint.port == dst_port;
 
                 mac_match && remote_match
             } else {
@@ -898,31 +885,23 @@ impl NatEngine {
         let existing = self.nat_table.iter().find(|(_, entry)| {
             match entry {
                 NatEntry::Tcp(entry) => {
-                    if let (IpAddress::Ipv4(mac_ip), IpAddress::Ipv4(remote_ip)) =
-                        (entry.local_endpoint.addr, entry.remote_endpoint.addr)
-                    {
-                        mac_ip == src_ip
-                            && entry.local_endpoint.port == src_port
-                            && remote_ip == dst_ip
-                            && entry.remote_endpoint.port == dst_port
-                    } else {
-                        false
-                    }
+                    let (IpAddress::Ipv4(mac_ip), IpAddress::Ipv4(remote_ip)) =
+                        (entry.local_endpoint.addr, entry.remote_endpoint.addr);
+                    mac_ip == src_ip
+                        && entry.local_endpoint.port == src_port
+                        && remote_ip == dst_ip
+                        && entry.remote_endpoint.port == dst_port
                 }
                 #[cfg(feature = "https_stripping")]
                 NatEntry::TcpHttpsStripping(entry) => {
                     // For HTTPS stripping, we check against the original port 80 connection
                     // Note: remote_endpoint stores port 80 (original), not 443
-                    if let (IpAddress::Ipv4(mac_ip), IpAddress::Ipv4(remote_ip)) =
-                        (entry.local_endpoint.addr, entry.remote_endpoint.addr)
-                    {
-                        mac_ip == src_ip
-                            && entry.local_endpoint.port == src_port
-                            && remote_ip == dst_ip
-                            && entry.remote_endpoint.port == dst_port
-                    } else {
-                        false
-                    }
+                    let (IpAddress::Ipv4(mac_ip), IpAddress::Ipv4(remote_ip)) =
+                        (entry.local_endpoint.addr, entry.remote_endpoint.addr);
+                    mac_ip == src_ip
+                        && entry.local_endpoint.port == src_port
+                        && remote_ip == dst_ip
+                        && entry.remote_endpoint.port == dst_port
                 }
                 _ => false,
             }
@@ -1157,14 +1136,8 @@ impl NatEngine {
                                 log::debug!("HTTPS stripping: Extracted Host: {}", hostname);
 
                                 // Establish TLS connection using the hostname for SNI
-                                let dst_ip_addr = match entry.remote_endpoint.addr {
-                                    IpAddress::Ipv4(ip) => std::net::IpAddr::V4(ip),
-                                    _ => {
-                                        log::error!("Non-IPv4 address in HTTPS stripping");
-                                        tls_failed = true;
-                                        return (buffer.len(), buffer.len());
-                                    }
-                                };
+                                let IpAddress::Ipv4(ip) = entry.remote_endpoint.addr;
+                                let dst_ip_addr = std::net::IpAddr::V4(ip);
 
                                 match https_stripping::HttpsStrippingStream::connect(
                                     &hostname,

--- a/nat/src/lib.rs
+++ b/nat/src/lib.rs
@@ -280,7 +280,7 @@ impl Device for VirtualDevice {
 
         // Intercept ICMP packets MacTCP Helpers can handle instead of smoltcp
         #[cfg(feature = "mactcp_helpers")]
-        if mactcp_helpers::needs_icmp_proxy(&packet) {
+        if mactcp_helpers::needs_icmp_answer(&packet) {
             self.intercepted_packets.push(packet);
             return None;
         }

--- a/nat/src/mactcp_helpers.rs
+++ b/nat/src/mactcp_helpers.rs
@@ -2,12 +2,14 @@
 //!
 //! This module enables helpers that are useful for MacTCP
 //! - ICMP delay
+//! - ICMP proxy-ish (handle Address Mask Requests)
 //! - RARP server
 
 use anyhow::Result;
+use smoltcp::phy::ChecksumCapabilities;
 use smoltcp::wire::{
     ArpHardware, ArpOperation, ArpPacket, EthernetAddress, EthernetFrame, EthernetProtocol,
-    IpProtocol, Ipv4Address, Ipv4Packet,
+    Icmpv4Message, Icmpv4Packet, IpProtocol, Ipv4Address, Ipv4Packet, Ipv4Repr,
 };
 use std::time::Duration;
 
@@ -62,6 +64,121 @@ pub fn handle_rarp_request(
     Ok(Some(buf))
 }
 
+/// Returns true if the packet is an ICMP Address Mask Request (type 17)
+pub fn needs_icmp_proxy(packet: &[u8]) -> bool {
+    let eth_hlen = EthernetFrame::<&[u8]>::header_len();
+    if packet.len() <= eth_hlen {
+        return false;
+    }
+    if EthernetFrame::new_unchecked(packet).ethertype() != EthernetProtocol::Ipv4 {
+        return false;
+    }
+    let ipv4 = match Ipv4Packet::new_checked(&packet[eth_hlen..]) {
+        Ok(p) => p,
+        Err(_) => return false,
+    };
+    if ipv4.next_header() != IpProtocol::Icmp {
+        return false;
+    }
+    Icmpv4Packet::new_checked(ipv4.payload())
+        .map(|icmp| icmp.msg_type() == Icmpv4Message::Unknown(17))
+        .unwrap_or(false)
+}
+
+/// Validate an ICMP Address Mask Request (type 17) and return the reply frame if ok
+pub fn handle_icmp_address_mask_request(
+    eth_frame: &EthernetFrame<&[u8]>,
+    gateway_ip: Ipv4Address,
+    gateway_mac: EthernetAddress,
+    subnet_prefix: u8,
+) -> Result<Option<Vec<u8>>> {
+    let ipv4 = match Ipv4Packet::new_checked(eth_frame.payload()) {
+        Ok(p) => p,
+        Err(_) => return Ok(None),
+    };
+    if ipv4.next_header() != IpProtocol::Icmp {
+        return Ok(None);
+    }
+    let icmp = match Icmpv4Packet::new_checked(ipv4.payload()) {
+        Ok(p) => p,
+        Err(_) => return Ok(None),
+    };
+    if icmp.msg_type() != Icmpv4Message::Unknown(17) || icmp.msg_code() != 0 {
+        return Ok(None);
+    }
+
+    let identifier = icmp.echo_ident();
+    let seq_no = icmp.echo_seq_no();
+
+    // It would be a better idea to be classful here, but the code in ethernet.rs is
+    // classless so let's follow that
+    let address_mask: u32 = if subnet_prefix == 0 {
+        0
+    } else {
+        !0u32 << (32 - subnet_prefix as u32)
+    };
+
+    let buf = build_icmp_address_mask_reply(
+        eth_frame.src_addr(),
+        gateway_ip,
+        gateway_mac,
+        address_mask,
+        identifier,
+        seq_no,
+    );
+    log::info!(
+        "ICMP: address mask request from {}, replying with {}",
+        ipv4.src_addr(),
+        Ipv4Address::from(address_mask.to_be_bytes())
+    );
+    Ok(Some(buf))
+}
+
+/// Build a full Ethernet + IPv4 + ICMP Address Mask Reply frame because smoltcp
+/// doesn't handle deprecated prehistoric stuff
+/// No idea if the answer should be unicast or broadcast, broadcast works for MacTCP
+fn build_icmp_address_mask_reply(
+    eth_dst: EthernetAddress,
+    gateway_ip: Ipv4Address,
+    gateway_mac: EthernetAddress,
+    address_mask: u32,
+    identifier: u16,
+    seq_no: u16,
+) -> Vec<u8> {
+    const ICMP_LEN: usize = 12;
+    let eth_hlen = EthernetFrame::<&[u8]>::header_len();
+    let ip_repr = Ipv4Repr {
+        src_addr: gateway_ip,
+        dst_addr: Ipv4Address::BROADCAST,
+        next_header: IpProtocol::Icmp,
+        payload_len: ICMP_LEN,
+        hop_limit: 1,
+    };
+    let total = eth_hlen + ip_repr.buffer_len() + ICMP_LEN;
+    let mut buf = vec![0u8; total];
+
+    let mut eth = EthernetFrame::new_unchecked(&mut buf);
+    eth.set_dst_addr(eth_dst);
+    eth.set_src_addr(gateway_mac);
+    eth.set_ethertype(EthernetProtocol::Ipv4);
+
+    let mut ipv4 = Ipv4Packet::new_unchecked(&mut buf[eth_hlen..]);
+    ip_repr.emit(&mut ipv4, &ChecksumCapabilities::default());
+
+    let icmp_start = eth_hlen + ip_repr.buffer_len();
+    let icmp_buf = &mut buf[icmp_start..];
+    icmp_buf[0] = 18;
+    icmp_buf[1] = 0;
+    icmp_buf[2] = 0;
+    icmp_buf[3] = 0;
+    icmp_buf[4..6].copy_from_slice(&identifier.to_be_bytes());
+    icmp_buf[6..8].copy_from_slice(&seq_no.to_be_bytes());
+    icmp_buf[8..12].copy_from_slice(&address_mask.to_be_bytes());
+    Icmpv4Packet::new_unchecked(icmp_buf).fill_checksum();
+
+    buf
+}
+
 /// Build a RARP reply frame with the specified IP.
 fn build_rarp_reply(
     client_mac: EthernetAddress,
@@ -73,22 +190,22 @@ fn build_rarp_reply(
         .to_be_bytes();
 
     let mut buf = vec![0u8; 42];
-    {
-        let mut frame = EthernetFrame::new_unchecked(&mut buf);
-        frame.set_dst_addr(client_mac);
-        frame.set_src_addr(gateway_mac);
-        frame.set_ethertype(EthernetProtocol::Unknown(0x8035));
 
-        let mut reply = ArpPacket::new_unchecked(frame.payload_mut());
-        reply.set_hardware_type(ArpHardware::Ethernet);
-        reply.set_protocol_type(EthernetProtocol::Ipv4);
-        reply.set_hardware_len(6);
-        reply.set_protocol_len(4);
-        reply.set_operation(ArpOperation::from(4u16));
-        reply.set_source_hardware_addr(gateway_mac.as_bytes());
-        reply.set_source_protocol_addr(&gateway_ip.octets());
-        reply.set_target_hardware_addr(client_mac.as_bytes());
-        reply.set_target_protocol_addr(&client_ip);
-    }
+    let mut frame = EthernetFrame::new_unchecked(&mut buf);
+    frame.set_dst_addr(client_mac);
+    frame.set_src_addr(gateway_mac);
+    frame.set_ethertype(EthernetProtocol::Unknown(0x8035));
+
+    let mut reply = ArpPacket::new_unchecked(frame.payload_mut());
+    reply.set_hardware_type(ArpHardware::Ethernet);
+    reply.set_protocol_type(EthernetProtocol::Ipv4);
+    reply.set_hardware_len(6);
+    reply.set_protocol_len(4);
+    reply.set_operation(ArpOperation::from(4u16));
+    reply.set_source_hardware_addr(gateway_mac.as_bytes());
+    reply.set_source_protocol_addr(&gateway_ip.octets());
+    reply.set_target_hardware_addr(client_mac.as_bytes());
+    reply.set_target_protocol_addr(&client_ip);
+
     buf
 }

--- a/nat/src/mactcp_helpers.rs
+++ b/nat/src/mactcp_helpers.rs
@@ -111,7 +111,7 @@ pub fn handle_icmp_address_mask_request(
     let identifier = icmp.echo_ident();
     let seq_no = icmp.echo_seq_no();
 
-    // It would be a better idea to be classful here, but the code in ethernet.rs is
+    // It would make more sense to be classful here, but the code in ethernet.rs is
     // classless so let's follow that
     let address_mask: u32 = if subnet_prefix == 0 {
         0
@@ -180,7 +180,7 @@ fn build_icmp_address_mask_reply(
     buf
 }
 
-/// Build a spoofed TCP RST+ACK frame from the remote endpoint, so MacTCP doesn't
+/// Build a spoofed TCP RST + ACK frame from the remote endpoint, so MacTCP doesn't
 /// hang while doing SYN retransmits
 pub fn build_tcp_rst(
     eth_dst: EthernetAddress,

--- a/nat/src/mactcp_helpers.rs
+++ b/nat/src/mactcp_helpers.rs
@@ -9,7 +9,8 @@ use anyhow::Result;
 use smoltcp::phy::ChecksumCapabilities;
 use smoltcp::wire::{
     ArpHardware, ArpOperation, ArpPacket, EthernetAddress, EthernetFrame, EthernetProtocol,
-    Icmpv4Message, Icmpv4Packet, IpProtocol, Ipv4Address, Ipv4Packet, Ipv4Repr,
+    Icmpv4Message, Icmpv4Packet, IpAddress, IpProtocol, Ipv4Address, Ipv4Packet, Ipv4Repr,
+    TcpPacket, TcpSeqNumber,
 };
 use std::time::Duration;
 
@@ -175,6 +176,52 @@ fn build_icmp_address_mask_reply(
     icmp_buf[6..8].copy_from_slice(&seq_no.to_be_bytes());
     icmp_buf[8..12].copy_from_slice(&address_mask.to_be_bytes());
     Icmpv4Packet::new_unchecked(icmp_buf).fill_checksum();
+
+    buf
+}
+
+/// Build a spoofed TCP RST+ACK frame from the remote endpoint, so MacTCP doesn't
+/// hang while doing SYN retransmits
+pub fn build_tcp_rst(
+    eth_dst: EthernetAddress,
+    gateway_mac: EthernetAddress,
+    src_ip: Ipv4Address,
+    dst_ip: Ipv4Address,
+    src_port: u16,
+    dst_port: u16,
+    ack_num: u32,
+) -> Vec<u8> {
+    const TCP_HEADER_LEN: usize = 20;
+    let eth_hlen = EthernetFrame::<&[u8]>::header_len();
+    let ip_repr = Ipv4Repr {
+        src_addr: src_ip,
+        dst_addr: dst_ip,
+        next_header: IpProtocol::Tcp,
+        payload_len: TCP_HEADER_LEN,
+        hop_limit: 64,
+    };
+    let total = eth_hlen + ip_repr.buffer_len() + TCP_HEADER_LEN;
+    let mut buf = vec![0u8; total];
+
+    let mut eth = EthernetFrame::new_unchecked(&mut buf);
+    eth.set_dst_addr(eth_dst);
+    eth.set_src_addr(gateway_mac);
+    eth.set_ethertype(EthernetProtocol::Ipv4);
+
+    let mut ipv4 = Ipv4Packet::new_unchecked(&mut buf[eth_hlen..]);
+    ip_repr.emit(&mut ipv4, &ChecksumCapabilities::default());
+
+    let tcp_start = eth_hlen + ip_repr.buffer_len();
+    let mut tcp = TcpPacket::new_unchecked(&mut buf[tcp_start..]);
+    tcp.set_src_port(src_port);
+    tcp.set_dst_port(dst_port);
+    tcp.set_seq_number(TcpSeqNumber(0));
+    tcp.set_ack_number(TcpSeqNumber(ack_num as i32));
+    tcp.set_header_len(20);
+    tcp.set_rst(true);
+    tcp.set_ack(true);
+    tcp.set_window_len(0);
+    tcp.fill_checksum(&IpAddress::Ipv4(src_ip), &IpAddress::Ipv4(dst_ip));
 
     buf
 }

--- a/nat/src/mactcp_helpers.rs
+++ b/nat/src/mactcp_helpers.rs
@@ -27,6 +27,8 @@ pub fn handle_rarp_request(
     }
 
     let client_mac = EthernetAddress::from_bytes(arp_packet.target_hardware_addr());
+
+    // IP will be Gateway IP + 1 (e.g: GW 10.0.0.1 -> Mac 10.0.0.2)
     let client_ip = Ipv4Address::from(
         u32::from_be_bytes(gateway_ip.octets())
             .wrapping_add(1)
@@ -37,7 +39,7 @@ pub fn handle_rarp_request(
     Ok(Some(buf))
 }
 
-/// Build a RARP reply frame. IP will be Gateway IP + 1 (e.g: GW 10.0.0.1 -> Mac 10.0.0.2)
+/// Build a RARP reply frame with the specified IP.
 pub fn build_rarp_reply(
     client_mac: EthernetAddress,
     gateway_mac: EthernetAddress,

--- a/nat/src/mactcp_helpers.rs
+++ b/nat/src/mactcp_helpers.rs
@@ -1,0 +1,68 @@
+//! MacTCP Helpers
+//!
+//! This module enables helpers that are useful for MacTCP
+//! - RARP server
+
+use anyhow::Result;
+use smoltcp::wire::{
+    ArpHardware, ArpOperation, ArpPacket, EthernetAddress, EthernetFrame, EthernetProtocol,
+    Ipv4Address,
+};
+
+/// Validate a RARP request and return the reply buffer, or None if not applicable
+pub fn handle_rarp_request(
+    eth_frame: &EthernetFrame<&[u8]>,
+    gateway_ip: Ipv4Address,
+    gateway_mac: EthernetAddress,
+) -> Result<Option<Vec<u8>>> {
+    let arp_packet = ArpPacket::new_checked(eth_frame.payload())
+        .map_err(|e| anyhow::anyhow!("Bad RARP packet: {:?}", e))?;
+
+    if arp_packet.operation() != ArpOperation::from(3u16)
+        || arp_packet.hardware_type() != ArpHardware::Ethernet
+        || arp_packet.hardware_len() != 6
+        || arp_packet.protocol_len() != 4
+    {
+        return Ok(None);
+    }
+
+    let client_mac = EthernetAddress::from_bytes(arp_packet.target_hardware_addr());
+    let client_ip = Ipv4Address::from(
+        u32::from_be_bytes(gateway_ip.octets())
+            .wrapping_add(1)
+            .to_be_bytes(),
+    );
+    let buf = build_rarp_reply(client_mac, gateway_mac, gateway_ip);
+    log::info!("RARP: assigned {} to {}", client_ip, client_mac);
+    Ok(Some(buf))
+}
+
+/// Build a RARP reply frame. IP will be Gateway IP + 1 (e.g: GW 10.0.0.1 -> Mac 10.0.0.2)
+pub fn build_rarp_reply(
+    client_mac: EthernetAddress,
+    gateway_mac: EthernetAddress,
+    gateway_ip: Ipv4Address,
+) -> Vec<u8> {
+    let client_ip = u32::from_be_bytes(gateway_ip.octets())
+        .wrapping_add(1)
+        .to_be_bytes();
+
+    let mut buf = vec![0u8; 42];
+    {
+        let mut frame = EthernetFrame::new_unchecked(&mut buf);
+        frame.set_dst_addr(client_mac);
+        frame.set_src_addr(gateway_mac);
+        frame.set_ethertype(EthernetProtocol::Unknown(0x8035));
+        let mut reply = ArpPacket::new_unchecked(frame.payload_mut());
+        reply.set_hardware_type(ArpHardware::Ethernet);
+        reply.set_protocol_type(EthernetProtocol::Ipv4);
+        reply.set_hardware_len(6);
+        reply.set_protocol_len(4);
+        reply.set_operation(ArpOperation::from(4u16));
+        reply.set_source_hardware_addr(gateway_mac.as_bytes());
+        reply.set_source_protocol_addr(&gateway_ip.octets());
+        reply.set_target_hardware_addr(client_mac.as_bytes());
+        reply.set_target_protocol_addr(&client_ip);
+    }
+    buf
+}

--- a/nat/src/mactcp_helpers.rs
+++ b/nat/src/mactcp_helpers.rs
@@ -1,13 +1,36 @@
 //! MacTCP Helpers
 //!
 //! This module enables helpers that are useful for MacTCP
+//! - ICMP delay
 //! - RARP server
 
 use anyhow::Result;
 use smoltcp::wire::{
     ArpHardware, ArpOperation, ArpPacket, EthernetAddress, EthernetFrame, EthernetProtocol,
-    Ipv4Address,
+    IpProtocol, Ipv4Address, Ipv4Packet,
 };
+use std::time::Duration;
+
+/// Amount of time we will throttle smoltcp TX before sending the ICMP reply
+const ICMP_REPLY_DELAY: Duration = Duration::from_millis(4);
+
+/// Put the TX thread into sleep for x ms if it's an ICMP reply
+pub fn delay_icmp_reply(buffer: &[u8]) {
+    let eth_hlen = EthernetFrame::<&[u8]>::header_len();
+    if buffer.len() <= eth_hlen {
+        return;
+    }
+    if EthernetFrame::new_unchecked(buffer).ethertype() != EthernetProtocol::Ipv4 {
+        return;
+    }
+    let ipv4 = match Ipv4Packet::new_checked(&buffer[eth_hlen..]) {
+        Ok(p) => p,
+        Err(_) => return,
+    };
+    if ipv4.next_header() == IpProtocol::Icmp {
+        std::thread::sleep(ICMP_REPLY_DELAY);
+    }
+}
 
 /// Validate a RARP request and return the reply buffer, or None if not applicable
 pub fn handle_rarp_request(
@@ -15,18 +38,17 @@ pub fn handle_rarp_request(
     gateway_ip: Ipv4Address,
     gateway_mac: EthernetAddress,
 ) -> Result<Option<Vec<u8>>> {
-    let arp_packet = ArpPacket::new_checked(eth_frame.payload())
-        .map_err(|e| anyhow::anyhow!("Bad RARP packet: {:?}", e))?;
+    let rarp_packet = ArpPacket::new_checked(eth_frame.payload()).expect("Bad RARP packet");
 
-    if arp_packet.operation() != ArpOperation::from(3u16)
-        || arp_packet.hardware_type() != ArpHardware::Ethernet
-        || arp_packet.hardware_len() != 6
-        || arp_packet.protocol_len() != 4
+    if rarp_packet.operation() != ArpOperation::from(3u16)
+        || rarp_packet.hardware_type() != ArpHardware::Ethernet
+        || rarp_packet.hardware_len() != 6
+        || rarp_packet.protocol_len() != 4
     {
         return Ok(None);
     }
 
-    let client_mac = EthernetAddress::from_bytes(arp_packet.target_hardware_addr());
+    let client_mac = EthernetAddress::from_bytes(rarp_packet.target_hardware_addr());
 
     // IP will be Gateway IP + 1 (e.g: GW 10.0.0.1 -> Mac 10.0.0.2)
     let client_ip = Ipv4Address::from(
@@ -34,13 +56,14 @@ pub fn handle_rarp_request(
             .wrapping_add(1)
             .to_be_bytes(),
     );
+
     let buf = build_rarp_reply(client_mac, gateway_mac, gateway_ip);
     log::info!("RARP: assigned {} to {}", client_ip, client_mac);
     Ok(Some(buf))
 }
 
 /// Build a RARP reply frame with the specified IP.
-pub fn build_rarp_reply(
+fn build_rarp_reply(
     client_mac: EthernetAddress,
     gateway_mac: EthernetAddress,
     gateway_ip: Ipv4Address,
@@ -55,6 +78,7 @@ pub fn build_rarp_reply(
         frame.set_dst_addr(client_mac);
         frame.set_src_addr(gateway_mac);
         frame.set_ethertype(EthernetProtocol::Unknown(0x8035));
+
         let mut reply = ArpPacket::new_unchecked(frame.payload_mut());
         reply.set_hardware_type(ArpHardware::Ethernet);
         reply.set_protocol_type(EthernetProtocol::Ipv4);

--- a/nat/src/mactcp_helpers.rs
+++ b/nat/src/mactcp_helpers.rs
@@ -66,7 +66,7 @@ pub fn handle_rarp_request(
 }
 
 /// Returns true if the packet is an ICMP Address Mask Request (type 17)
-pub fn needs_icmp_proxy(packet: &[u8]) -> bool {
+pub fn needs_icmp_answer(packet: &[u8]) -> bool {
     let eth_hlen = EthernetFrame::<&[u8]>::header_len();
     if packet.len() <= eth_hlen {
         return false;


### PR DESCRIPTION
Hello,

Trying to improve a few things in snow_nat, This is a WIP of stuff I'm working on

- [X] upgrade smoltcp to 0.12.0:
     - [X] fix FreeBSD build 
     - [X] filter ARP requests to smoltcp
- [X] upgrade smoltcp to 0.13.1
- [X] try to fix #239 
     - [X] Throttle ICMP replies
- [X] fix NAT GW MAC address (It has currently the group multicast bit set)
- [x] try to find why some DNS queries are lost
- [x] try to find why DNS Lookup 0.92 doesn't work
- [x] cargo trim smoltcp features if needed. We certainly don't need to bring in proto-sixlowpan
- [x] try to give MacTCP some ICMP feedback for #250 (ICMP error).
- [X] try to give MacTCP some ICMP feedback for refused connections from the host (os error 61)
     - [X] doesn't work, spoofing RST works however
- [X] NATed UDP packets come back with the Gateway IP Address instead of the remote host IP
- [X] NAT Gateway filtering:
     - [X] from IP source 0.0.0.0, avoid "Can't assign requested address (os error 49)"
     - [X] privileged source ports < 1024
     - [X] broadcast paquets, avoid "Address family not supported by protocol family (os error 47)"
     - [X] add debug props for filtered packets
     - [X] don't NAT RIP packets
     - [X] comprehensive debug logging about what is being filtered
- [X] NAT mode: implement server autoconfiguration for MacTCP
     - [X] Implement a tiny RARP server
     - [X] Handle ICMP Address Mask Requests

Notes: 
- Starting 0.12.0 smoltcp answer ARP requests for _any_ IP address on the network (it now honour any_ip mode). This trigger MacTCP duplicate IP address mechanism. Needs a fix before merge
- smoltcp API changed in 0.12.0, needs a few tweaks
- FreeBSD build supported since 0.12.0

<img width="852" height="327" alt="duplicate" src="https://github.com/user-attachments/assets/41975e8a-625b-422f-85ac-45b03fd25d1f" />