### PR TITLE
Implement floppy writeback for MOOF, reorganize Options menu, change alternate Cmd key mapping to global setting

### DIFF
--- a/core/src/emulator/comm.rs
+++ b/core/src/emulator/comm.rs
@@ -40,6 +40,9 @@ pub enum EmulatorCommand {
     InsertFloppyImage(usize, Box<FloppyImage>, bool),
     SaveFloppy(usize, PathBuf),
     EjectFloppy(usize),
+    /// Toggle automatic writeback for a floppy drive.
+    /// Parameters: drive id, enabled
+    SetFloppyWriteback(usize, bool),
     ScsiAttachHdd(usize, PathBuf),
     ScsiBranchHdd(usize, PathBuf),
     ScsiAttachCdrom(usize),
@@ -161,6 +164,11 @@ pub struct FddStatus {
     pub image_title: String,
     pub dirty: bool,
     pub drive_type: crate::mac::swim::drive::DriveType,
+    /// True if the loaded image's source format supports writeback and was
+    /// loaded from a file on disk (i.e. writeback is possible).
+    pub writeback_supported: bool,
+    /// True if writeback is currently armed for this drive.
+    pub writeback_enabled: bool,
 }
 
 /// A friendly message ready for display to a user

--- a/core/src/emulator/comm.rs
+++ b/core/src/emulator/comm.rs
@@ -154,7 +154,7 @@ pub struct ScsiTargetStatus {
     pub capture_status: Option<EthernetCaptureStatus>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct FddStatus {
     pub present: bool,
     pub ejected: bool,

--- a/core/src/emulator/mod.rs
+++ b/core/src/emulator/mod.rs
@@ -589,6 +589,9 @@ impl Emulator {
                     image_title: self.config.swim().drives[i].floppy.get_title().to_owned(),
                     dirty: self.config.swim().drives[i].floppy.is_dirty(),
                     drive_type: self.config.swim().drives[i].drive_type,
+                    writeback_supported: self.config.swim().drives[i].image_path.is_some()
+                        && self.config.swim().drives[i].floppy.supports_writeback(),
+                    writeback_enabled: self.config.swim().drives[i].writeback_enabled,
                 }),
                 model: self.model,
                 scsi: core::array::from_fn(|i| {
@@ -764,6 +767,62 @@ impl Emulator {
         info!("{}", msg);
     }
 
+    /// Saves the floppy in `drive` back to its source file using the MOOF
+    /// writer. No-op if writeback is not currently armed for the drive.
+    /// Clears the dirty + pending flags on success.
+    fn try_writeback(&mut self, drive: usize) {
+        let drv = &self.config.swim().drives[drive];
+        if !drv.writeback_enabled || !drv.floppy.is_dirty() {
+            return;
+        }
+        let Some(path) = drv.image_path.clone() else {
+            return;
+        };
+
+        let result = crate::util::atomic_write(&path, |f| {
+            Moof::write(&self.config.swim().drives[drive].floppy, f)
+        });
+
+        let display_name = path
+            .file_name()
+            .map(|n| n.to_string_lossy().into_owned())
+            .unwrap_or_else(|| path.display().to_string());
+
+        match result {
+            Ok(()) => {
+                let drv = &mut self.config.swim_mut().drives[drive];
+                drv.floppy.clear_dirty();
+                drv.pending_writeback = false;
+                log::info!(
+                    "Floppy #{}: writeback auto-saved '{}'",
+                    drive + 1,
+                    display_name
+                );
+            }
+            Err(e) => {
+                self.config.swim_mut().drives[drive].pending_writeback = false;
+                self.user_error(&format!(
+                    "Floppy #{}: writeback to '{}' failed: {:#}",
+                    drive + 1,
+                    display_name,
+                    e
+                ));
+            }
+        }
+    }
+
+    /// Drains queued writeback requests across all drives. With `force`,
+    /// ignores [`FloppyDrive::pending_writeback`] and saves any dirty drive
+    /// that has writeback armed.
+    fn flush_pending_writebacks(&mut self, force: bool) {
+        for i in 0..self.config.swim().drives.len() {
+            let drv = &self.config.swim().drives[i];
+            if drv.writeback_enabled && (force || drv.pending_writeback) && drv.floppy.is_dirty() {
+                self.try_writeback(i);
+            }
+        }
+    }
+
     #[inline(always)]
     fn try_step(&mut self) {
         if let Err(e) = self.step() {
@@ -847,6 +906,7 @@ impl Tickable for Emulator {
                     }
                     EmulatorCommand::Quit => {
                         info!("Emulator terminating");
+                        self.flush_pending_writebacks(true);
                         self.config.video_blank()?;
                         return Ok(0);
                     }
@@ -857,8 +917,15 @@ impl Tickable for Emulator {
                                 if wp {
                                     img.set_force_wp();
                                 }
+                                let writeback_path =
+                                    img.supports_writeback().then(|| PathBuf::from(&filename));
                                 if let Err(e) = self.config.swim_mut().disk_insert(drive, img) {
                                     self.user_error(&format!("Cannot insert disk: {}", e));
+                                } else {
+                                    let drv = &mut self.config.swim_mut().drives[drive];
+                                    drv.image_path = writeback_path;
+                                    drv.writeback_enabled = false;
+                                    drv.pending_writeback = false;
                                 }
                             }
                             Err(e) => {
@@ -880,7 +947,28 @@ impl Tickable for Emulator {
                         self.status_update()?;
                     }
                     EmulatorCommand::EjectFloppy(drive) => {
+                        self.try_writeback(drive);
                         self.config.swim_mut().drives[drive].eject();
+                    }
+                    EmulatorCommand::SetFloppyWriteback(drive, enabled) => {
+                        let ok = {
+                            let drv = &mut self.config.swim_mut().drives[drive];
+                            if enabled
+                                && (drv.image_path.is_none() || !drv.floppy.supports_writeback())
+                            {
+                                false
+                            } else {
+                                drv.writeback_enabled = enabled;
+                                drv.pending_writeback = false;
+                                true
+                            }
+                        };
+                        if !ok {
+                            self.user_error(
+                                "Writeback unavailable: image was not loaded from a writeback-capable file",
+                            );
+                        }
+                        self.status_update()?;
                     }
                     EmulatorCommand::ScsiAttachHdd(id, filename) => {
                         match self.load_hdd_image(&filename, id) {
@@ -1357,6 +1445,10 @@ impl Tickable for Emulator {
                     }
                 }
             }
+
+            // Honour any writeback requests raised during this tick batch
+            // (e.g. by the SWIM controller turning a drive motor off).
+            self.flush_pending_writebacks(false);
         } else {
             thread::sleep(Duration::from_millis(100));
         }

--- a/core/src/emulator/mod.rs
+++ b/core/src/emulator/mod.rs
@@ -767,9 +767,9 @@ impl Emulator {
         info!("{}", msg);
     }
 
-    /// Saves the floppy in `drive` back to its source file using the MOOF
-    /// writer. No-op if writeback is not currently armed for the drive.
-    /// Clears the dirty + pending flags on success.
+    /// Saves the floppy in `drive` back to its source file using the writer
+    /// matching its source format. No-op if writeback is not currently armed
+    /// for the drive. Clears the dirty + pending flags on success.
     fn try_writeback(&mut self, drive: usize) {
         let drv = &self.config.swim().drives[drive];
         if !drv.writeback_enabled || !drv.floppy.is_dirty() {
@@ -780,7 +780,7 @@ impl Emulator {
         };
 
         let result = crate::util::atomic_write(&path, |f| {
-            Moof::write(&self.config.swim().drives[drive].floppy, f)
+            snow_floppy::loaders::save_image(&self.config.swim().drives[drive].floppy, f)
         });
 
         let display_name = path

--- a/core/src/mac/swim/drive.rs
+++ b/core/src/mac/swim/drive.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 use anyhow::Result;
 use log::*;
 use num_derive::FromPrimitive;
@@ -253,6 +255,21 @@ pub(crate) struct FloppyDrive {
 
     /// Cached ticks-per-bit
     ticks_per_bit: Ticks,
+
+    /// Source file path of the currently inserted image, if it was loaded
+    /// from a writeback-capable file. Cleared on eject.
+    #[serde(skip)]
+    pub(crate) image_path: Option<PathBuf>,
+
+    /// Per-drive writeback opt-in. Only meaningful when [`Self::image_path`]
+    /// is set and `floppy.supports_writeback()`.
+    #[serde(skip)]
+    pub(crate) writeback_enabled: bool,
+
+    /// Set by [`DriveWriteReg::MOTOROFF`] when a writeback save is due. The
+    /// emulator polls this and clears it after attempting the save.
+    #[serde(skip)]
+    pub(crate) pending_writeback: bool,
 }
 
 impl FloppyDrive {
@@ -291,6 +308,10 @@ impl FloppyDrive {
             pwm_dutycycle: 0,
             rpm_adjustment: 0,
             ticks_per_bit: Ticks::MAX,
+
+            image_path: None,
+            writeback_enabled: false,
+            pending_writeback: false,
         }
     }
 
@@ -398,6 +419,9 @@ impl FloppyDrive {
             }
             DriveWriteReg::MOTOROFF => {
                 self.motor = false;
+                if self.writeback_enabled && self.image_path.is_some() && self.floppy.is_dirty() {
+                    self.pending_writeback = true;
+                }
             }
             DriveWriteReg::EJECT => {
                 if self.floppy_inserted {
@@ -569,6 +593,10 @@ impl FloppyDrive {
         self.mfm = self.drive_type.io_mfm();
 
         self.floppy_ejected = Some(Box::new(self.floppy.clone()));
+
+        self.image_path = None;
+        self.writeback_enabled = false;
+        self.pending_writeback = false;
     }
 
     pub(crate) fn take_ejected_image(&mut self) -> Option<Box<FloppyImage>> {

--- a/core/src/util/mod.rs
+++ b/core/src/util/mod.rs
@@ -2,9 +2,11 @@ pub mod lossyinto;
 pub mod mac;
 
 use std::ops::{Mul, SubAssign};
+use std::path::Path;
 use std::sync::{Arc, RwLock};
 use std::time::Instant;
 
+use anyhow::{Context, Result};
 use num::{PrimInt, Signed};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
@@ -28,6 +30,46 @@ pub fn take_from_accumulator<T: PrimInt + Signed + Mul<Output = T> + SubAssign>(
 /// Serde default helper for Instant::now()
 pub fn instant_now() -> Instant {
     Instant::now()
+}
+
+/// Atomically writes to `path`. Calls `write` against a sibling temp file,
+/// fsyncs, then renames over the destination so a crash mid-write cannot
+/// leave a truncated file in place.
+pub fn atomic_write<F>(path: &Path, write: F) -> Result<()>
+where
+    F: FnOnce(&mut std::fs::File) -> Result<()>,
+{
+    use rand::Rng;
+    use std::fs;
+
+    let parent = path
+        .parent()
+        .filter(|p| !p.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."));
+    let stem = path
+        .file_name()
+        .context("Destination path has no file name")?;
+
+    let suffix: u64 = rand::rng().random();
+    let mut tmp_name = stem.to_owned();
+    tmp_name.push(format!(".tmp.{:016x}", suffix));
+    let tmp_path = parent.join(tmp_name);
+
+    let result = (|| {
+        let mut f = fs::File::create(&tmp_path)
+            .with_context(|| format!("Creating temp file {}", tmp_path.display()))?;
+        write(&mut f)?;
+        f.sync_all()?;
+        drop(f);
+        fs::rename(&tmp_path, path)
+            .with_context(|| format!("Renaming {} -> {}", tmp_path.display(), path.display()))?;
+        Ok(())
+    })();
+
+    if result.is_err() {
+        let _ = fs::remove_file(&tmp_path);
+    }
+    result
 }
 
 /// serialize_with helper for Arc::RwLock<T>

--- a/docs/src/manual/emulator.md
+++ b/docs/src/manual/emulator.md
@@ -14,7 +14,7 @@ While fast-forward mode is on, a number in the button indicates how much faster 
 speed) the emulation is running. While fast-forward mode is on, sound is disabled.
 
 You can enable and set a limit to how much faster the emulated system can run using the
-'Options -> Limit fast-forward speed' menu option.
+'Options -> Speed -> Limit fast-forward speed' menu option.
 
 Snow also has a 'Dynamic fast-forward' setting. When enabled, Snow will automatically switch
 back and forth between fast-forward and normal speed if fast-forward is enabled. If 

--- a/docs/src/manual/fullscreen.md
+++ b/docs/src/manual/fullscreen.md
@@ -14,8 +14,8 @@ toast shows.
 When switching to fullscreen mode, Snow will automatically switch to
 [relative mouse positioning mode](input.md#mouse) to provide the best experience
 and back to the original mode when leaving fullscreen. This behavior can be
-enabled/disabled using the 'Options > Use relative mouse in fullscreen' menu option.
-This option persists globally.
+enabled/disabled using the 'Options > Input > Use relative mouse in fullscreen' menu
+option. This option persists globally.
 
 ## Zen mode
 

--- a/docs/src/manual/input.md
+++ b/docs/src/manual/input.md
@@ -58,7 +58,7 @@ press the Command key, but since this is rather inconvenient, Snow provides
 the right ALT or CTRL as an alternative.
 
 To enable or disable mapping an alternate key for Command, use the menu item
-'Options > Map alternate Cmd key'. This option persists globally.
+'Options > Input > Map alternate Cmd key'. This option persists globally.
 
 ## Mouse
 
@@ -89,5 +89,5 @@ some games (e.g. first person shooters) and non-original software.
 Relative positioning mode works best when using Snow [fullscreen](fullscreen.md).
 When switching to fullscreen mode, Snow will automatically switch to relative
 positioning mode and back to the original mode when leaving fullscreen. This
-behavior can be enabled/disabled using the 'Options > Use relative mouse in
-fullscreen' menu option. This option persists globally.
+behavior can be enabled/disabled using the 'Options > Input > Use relative mouse
+in fullscreen' menu option. This option persists globally.

--- a/docs/src/manual/media/floppies.md
+++ b/docs/src/manual/media/floppies.md
@@ -44,8 +44,8 @@ and select 'Load image' to browse to the image you want to load.
 
 In the image browser you can view the metadata for the selected image on the right
 side. To mount an image as write-protected, check the 'Mount write-protected' box.
-Note that Snow will not automatically write back to your image file, even if an
-image is not mounted write-protected.
+For writable mounts, see [Automatic writeback](#automatic-writeback) below for
+how and when changes are written to the disk image.
 
 You can also mount an empty (400K/800K only currently) floppy which you can
 format and write to by selecting 'Insert blank 400K/800K floppy'.
@@ -69,15 +69,66 @@ to using a paperclip to forcibly eject a floppy on real hardware.
 ## Writing to floppies
 
 When a floppy is written to, the icon in the menu bar will change:
- * <span class="material-symbols-rounded">save</span> indicates the floppy has not been written to.
- * <span class="material-symbols-rounded">save_as</span> indicates the floppy was written
-to since it was mounted.
+ * <span class="material-symbols-rounded">save</span> indicates the floppy has
+   not been written to.
+ * <span class="material-symbols-rounded">save_as</span> indicates the floppy
+   was written to since it was mounted.
+ * <span class="material-symbols-rounded">autorenew</span> indicates
+   [automatic writeback](#automatic-writeback) is enabled for the floppy.
 
 To save a floppy including any changes, use the 'Save image...' item. If the floppy
 was ejected, you can use 'Save last ejected image...' to save the image from before
 the floppy was ejected, including changes.
 
-Note that Snow will never automatically write back to loaded floppy images - every
-save must be done explicitly.
-
 Floppy images are always saved in MOOF format.
+
+## Automatic writeback
+
+Snow can also write changes back to a floppy image's source file automatically,
+as the emulated system writes to it. With writeback enabled for a drive, you do
+not need to remember 'Save image...' - the source file is automatically saved.
+
+Writeback is only supported for MOOF images, since MOOF is the only format
+Snow can write. For other formats, Snow can offer to convert the image to a
+sibling MOOF on load (see [Behavior on floppy load](#behavior-on-floppy-load)
+below).
+
+### Enabling writeback for a drive
+
+When writeback is on for a drive, the floppy icon in the menubar shows
+<span class="material-symbols-rounded">autorenew</span>. You can toggle writeback
+for the currently loaded image at any time via the 'Auto-save changes (writeback)'
+checkbox in the drive's submenu under 'Drives'. The option is disabled when
+the loaded image is not a MOOF.
+
+### Behavior on floppy load
+
+When loading a floppy, Snow may prompt you before the image is inserted:
+
+ * **A sibling MOOF exists.** If you load a non-MOOF image and a `.moof` file
+   with the same filename exists alongside it, Snow asks whether to load the MOOF
+   file instead.
+ * **The image can be converted to MOOF.** If the image format does not support
+   writeback but the image can be converted to MOOF (sector or bitstream
+   images, but not flux-only images), Snow offers to write a sibling `.moof`
+   and load that. The original file is left untouched.
+ * **Enable writeback?** Once the loaded image supports writeback, Snow asks
+   whether to enable writeback for this image.
+
+The default behavior for each prompt is configurable under 'Options > Floppy':
+
+ * **Writeback** (Ask each time / Always enable / Never enable) - what Snow
+   does when a writeback-capable image is loaded.
+ * **Convert to MOOF** (Ask each time / Always convert / Never convert) -
+   whether to convert non-MOOF images to a sibling MOOF on load.
+
+Each prompt has a 'Remember my choice' option that updates the corresponding
+setting.
+
+### Backups
+
+Writeback overwrites the source file. To make it easy to revert, enable
+'Options > Floppy > Back up floppy image before enabling writeback'. With this
+on, Snow copies the image to a timestamped sibling in the same directory just
+before writeback is enabled for it, e.g. `MyDisk-bak 2026-05-14 130700.moof`.
+The backup is taken once per writeback activation, not on every write.

--- a/floppy/src/lib.rs
+++ b/floppy/src/lib.rs
@@ -183,6 +183,10 @@ pub struct FloppyImage {
 
     /// Force floppy read-only
     force_wp: bool,
+
+    /// True if the source format has a corresponding writer, so this image
+    /// can be written back to a file in its original format.
+    writeback_supported: bool,
 }
 
 impl FloppyImage {
@@ -223,6 +227,7 @@ impl FloppyImage {
             origtracktype: [Default::default(); FLOPPY_MAX_SIDES],
             dirty: false,
             force_wp: false,
+            writeback_supported: false,
         }
     }
 
@@ -283,6 +288,23 @@ impl FloppyImage {
     /// Check if image was written to
     pub fn is_dirty(&self) -> bool {
         self.dirty
+    }
+
+    /// Marks the image as clean. Call after a successful save.
+    pub fn clear_dirty(&mut self) {
+        self.dirty = false;
+    }
+
+    /// True if this image's original format has a writer available, so it
+    /// can be written back to a file in the same format.
+    pub fn supports_writeback(&self) -> bool {
+        self.writeback_supported
+    }
+
+    /// Marks the image as writeback-capable. Loaders for formats with a
+    /// corresponding [`FloppyImageSaver`] should call this.
+    pub fn set_writeback_supported(&mut self, v: bool) {
+        self.writeback_supported = v;
     }
 
     /// Forces floppy to be write-protected

--- a/floppy/src/lib.rs
+++ b/floppy/src/lib.rs
@@ -9,6 +9,7 @@ use serde::{Deserialize, Serialize};
 use serde_big_array::{Array, BigArray};
 use strum::EnumIter;
 
+use crate::loaders::ImageType;
 use flux::FluxTicks;
 
 pub mod built_info {
@@ -184,9 +185,9 @@ pub struct FloppyImage {
     /// Force floppy read-only
     force_wp: bool,
 
-    /// True if the source format has a corresponding writer, so this image
-    /// can be written back to a file in its original format.
-    writeback_supported: bool,
+    /// Format the image was loaded from. `None` for freshly-created images.
+    /// Used by [`loaders::save_image`] to dispatch to the matching writer.
+    source_format: Option<ImageType>,
 }
 
 impl FloppyImage {
@@ -227,7 +228,7 @@ impl FloppyImage {
             origtracktype: [Default::default(); FLOPPY_MAX_SIDES],
             dirty: false,
             force_wp: false,
-            writeback_supported: false,
+            source_format: None,
         }
     }
 
@@ -295,16 +296,22 @@ impl FloppyImage {
         self.dirty = false;
     }
 
-    /// True if this image's original format has a writer available, so it
-    /// can be written back to a file in the same format.
-    pub fn supports_writeback(&self) -> bool {
-        self.writeback_supported
+    /// Format this image was loaded from, if any.
+    pub fn source_format(&self) -> Option<ImageType> {
+        self.source_format
     }
 
-    /// Marks the image as writeback-capable. Loaders for formats with a
-    /// corresponding [`FloppyImageSaver`] should call this.
-    pub fn set_writeback_supported(&mut self, v: bool) {
-        self.writeback_supported = v;
+    /// Records the source format. Loaders should call this so writeback can
+    /// dispatch to the matching [`FloppyImageSaver`] via [`loaders::save_image`].
+    pub fn set_source_format(&mut self, fmt: ImageType) {
+        self.source_format = Some(fmt);
+    }
+
+    /// True iff the source format has a corresponding writer registered with
+    /// [`loaders::save_image`], so the image can be written back in its
+    /// original format.
+    pub fn supports_writeback(&self) -> bool {
+        self.source_format.is_some_and(loaders::format_has_saver)
     }
 
     /// Forces floppy to be write-protected

--- a/floppy/src/loaders/auto.rs
+++ b/floppy/src/loaders/auto.rs
@@ -9,10 +9,12 @@ use crate::{FloppyImage, FloppyType};
 
 use anyhow::{Result, bail};
 use serde::{Deserialize, Serialize};
-use strum::{Display, IntoEnumIterator};
+use strum::{Display, EnumIter, IntoEnumIterator};
 
 /// Types of supported floppy images
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Display, Copy, Clone, Serialize, Deserialize)]
+#[derive(
+    Debug, PartialEq, Eq, PartialOrd, Ord, Display, Copy, Clone, Serialize, Deserialize, EnumIter,
+)]
 pub enum ImageType {
     A2R2,
     A2R3,
@@ -27,9 +29,31 @@ pub enum ImageType {
 }
 
 impl ImageType {
-    pub const EXTENSIONS: [&'static str; 10] = [
-        "a2r", "moof", "dart", "dc42", "dsk", "pfi", "pri", "raw", "img", "image",
-    ];
+    /// Extension hints. Actual image type detection should occur through
+    /// the autoloader.
+    pub fn extensions(self) -> &'static [&'static str] {
+        match self {
+            Self::A2R2 | Self::A2R3 => &["a2r"],
+            Self::Bitfile => &[],
+            Self::DART => &["dart"],
+            Self::DC42 => &["dc42", "dsk"],
+            Self::Fluxfox => &[],
+            Self::MOOF => &["moof"],
+            Self::PFI => &["pfi"],
+            Self::PRI => &["pri"],
+            Self::Raw => &["dsk", "raw", "img", "image"],
+        }
+    }
+
+    /// All extensions across every supported format, de-duplicated.
+    pub fn all_extensions() -> Vec<&'static str> {
+        let mut out: Vec<&'static str> = Self::iter()
+            .flat_map(|t| t.extensions().iter().copied())
+            .collect();
+        out.sort_unstable();
+        out.dedup();
+        out
+    }
 
     pub fn as_friendly_str(&self) -> &'static str {
         match self {

--- a/floppy/src/loaders/auto.rs
+++ b/floppy/src/loaders/auto.rs
@@ -8,10 +8,11 @@ use crate::loaders::{
 use crate::{FloppyImage, FloppyType};
 
 use anyhow::{Result, bail};
+use serde::{Deserialize, Serialize};
 use strum::{Display, IntoEnumIterator};
 
 /// Types of supported floppy images
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Display, Copy, Clone)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Display, Copy, Clone, Serialize, Deserialize)]
 pub enum ImageType {
     A2R2,
     A2R3,

--- a/floppy/src/loaders/mod.rs
+++ b/floppy/src/loaders/mod.rs
@@ -30,10 +30,20 @@ pub use raw::RawImage;
 use crate::FloppyImage;
 
 use anyhow::Result;
+use strum::IntoEnumIterator;
 
 /// True if a FloppyImageSaver is implemented for an `ImageType`
 pub fn format_has_saver(fmt: ImageType) -> bool {
     matches!(fmt, ImageType::MOOF)
+}
+
+/// True if `ext` matches an extension associated with at least one format
+/// that has a FloppyImageSaver.
+pub fn extension_has_saver(ext: &std::ffi::OsStr) -> bool {
+    ImageType::iter()
+        .filter(|t| format_has_saver(*t))
+        .flat_map(|t| t.extensions().iter().copied())
+        .any(|e| ext.eq_ignore_ascii_case(e))
 }
 
 /// A loader to read a specific format and transform it into a usable FloppyImage

--- a/floppy/src/loaders/mod.rs
+++ b/floppy/src/loaders/mod.rs
@@ -31,6 +31,11 @@ use crate::FloppyImage;
 
 use anyhow::Result;
 
+/// True if a FloppyImageSaver is implemented for an `ImageType`
+pub fn format_has_saver(fmt: ImageType) -> bool {
+    matches!(fmt, ImageType::MOOF)
+}
+
 /// A loader to read a specific format and transform it into a usable FloppyImage
 pub trait FloppyImageLoader {
     fn load(data: &[u8], filename: Option<&str>) -> Result<FloppyImage>;
@@ -58,5 +63,18 @@ pub trait FloppyImageSaver {
         let mut f = std::fs::File::create(filename)?;
         Self::write(img, &mut f)?;
         Ok(())
+    }
+}
+
+/// Writes `img` to `w` in its original format. Returns an error if the
+/// image has no recorded source format, or if no FloppyImageSaver is
+/// implemented for that format (see format_has_saver).
+pub fn save_image(img: &FloppyImage, w: &mut impl std::io::Write) -> Result<()> {
+    let fmt = img
+        .source_format()
+        .ok_or_else(|| anyhow::anyhow!("Image has no recorded source format"))?;
+    match fmt {
+        ImageType::MOOF => Moof::write(img, w),
+        other => anyhow::bail!("No saver available for format {}", other),
     }
 }

--- a/floppy/src/loaders/moof.rs
+++ b/floppy/src/loaders/moof.rs
@@ -284,6 +284,8 @@ impl FloppyImageLoader for Moof {
             }
         }
 
+        img.set_writeback_supported(true);
+
         Ok(img)
     }
 }

--- a/floppy/src/loaders/moof.rs
+++ b/floppy/src/loaders/moof.rs
@@ -284,7 +284,12 @@ impl FloppyImageLoader for Moof {
             }
         }
 
-        img.set_source_format(super::ImageType::MOOF);
+        // TODO save and write support for flux images
+        let has_flux = (0..FLOPPY_MAX_SIDES)
+            .any(|s| (0..FLOPPY_MAX_TRACKS).any(|t| img.get_track_type(s, t) == TrackType::Flux));
+        if !has_flux {
+            img.set_source_format(super::ImageType::MOOF);
+        }
 
         Ok(img)
     }

--- a/floppy/src/loaders/moof.rs
+++ b/floppy/src/loaders/moof.rs
@@ -284,7 +284,7 @@ impl FloppyImageLoader for Moof {
             }
         }
 
-        img.set_writeback_supported(true);
+        img.set_source_format(super::ImageType::MOOF);
 
         Ok(img)
     }

--- a/frontend_egui/src/app.rs
+++ b/frontend_egui/src/app.rs
@@ -103,6 +103,16 @@ enum PendingConfirm {
     /// Button indices: 0 = enable writeback, 1 = leave disabled.
     /// 'Remember' enabled.
     Writeback { driveidx: usize },
+    /// User picked an image whose format has no writer and no MOOF sibling
+    /// exists. Offer to save them as a sibling file.
+    /// Button indices: 0 = save MOOF and load it, 1 = load original, 2 = cancel.
+    OfferMoofConversion {
+        driveidx: usize,
+        original: PathBuf,
+        moof_path: PathBuf,
+        moof_bytes: Vec<u8>,
+        wp: bool,
+    },
 }
 
 #[derive(Clone)]
@@ -1180,6 +1190,28 @@ impl SnowGui {
                         self.settings.save();
                     }
                 });
+                ui.menu_button("Convert floppy images to MOOF", |ui| {
+                    ui.set_min_width(Self::SUBMENU_WIDTH);
+                    let prev = self.settings.convert_to_moof_mode;
+                    ui.radio_value(
+                        &mut self.settings.convert_to_moof_mode,
+                        PromptChoice::Ask,
+                        "Ask each time",
+                    );
+                    ui.radio_value(
+                        &mut self.settings.convert_to_moof_mode,
+                        PromptChoice::Always,
+                        "Always convert",
+                    );
+                    ui.radio_value(
+                        &mut self.settings.convert_to_moof_mode,
+                        PromptChoice::Never,
+                        "Never convert",
+                    );
+                    if self.settings.convert_to_moof_mode != prev {
+                        self.settings.save();
+                    }
+                });
                 if ui
                     .checkbox(
                         &mut self.settings.fastforward_limit_enabled,
@@ -2027,8 +2059,9 @@ impl SnowGui {
     }
 
     /// Loads `path` into `driveidx`. If a sibling `.moof` is found alongside
-    /// a non-MOOF image, prompts the user to choose. Updates the recent
-    /// images list with whichever path actually loads.
+    /// a non-MOOF image, prompts the user to choose. If the format has no
+    /// writer but converting to MOOF would succeed, offers to save a
+    /// sibling MOOF.
     pub fn request_load_floppy(&mut self, driveidx: usize, path: &Path, wp: bool) {
         if let Some(moof) = Self::moof_sibling(path) {
             self.pending_confirm = PendingConfirm::MoofVariant {
@@ -2047,8 +2080,90 @@ impl SnowGui {
                 ),
                 vec!["Load MOOF".into(), "Load original".into(), "Cancel".into()],
             );
+        } else if self.maybe_offer_moof_conversion(driveidx, path, wp) {
+            // Dialog opened; wait for answer.
         } else {
             self.do_load_floppy(driveidx, path, wp);
+        }
+    }
+
+    fn maybe_offer_moof_conversion(&mut self, driveidx: usize, path: &Path, wp: bool) -> bool {
+        if wp || self.settings.convert_to_moof_mode == PromptChoice::Never {
+            return false;
+        }
+        if path
+            .extension()
+            .is_some_and(snow_floppy::loaders::extension_has_saver)
+        {
+            // Format has a saver, no conversion needed.
+            return false;
+        }
+        let moof_path = path.with_extension("moof");
+        if moof_path.exists() {
+            // Already has a MOOF sibling.
+            return false;
+        }
+
+        // Try to parse and re-render as MOOF. If either step fails, the
+        // format isn't convertible (e.g. flux tracks) and we silently
+        // fall through to a plain load.
+        let Ok(data) = std::fs::read(path) else {
+            return false;
+        };
+        let Ok(image) = snow_floppy::loaders::Autodetect::load(
+            &data,
+            path.file_name().and_then(|s| s.to_str()),
+        ) else {
+            return false;
+        };
+        let mut moof_bytes = Vec::new();
+        if snow_floppy::loaders::Moof::write(&image, &mut moof_bytes).is_err() {
+            return false;
+        }
+
+        match self.settings.convert_to_moof_mode {
+            PromptChoice::Always => {
+                match std::fs::write(&moof_path, &moof_bytes) {
+                    Ok(()) => self.do_load_floppy(driveidx, &moof_path, wp),
+                    Err(e) => {
+                        self.show_error(&format!(
+                            "Could not save '{}': {}",
+                            moof_path.display(),
+                            e
+                        ));
+                        // Fall back to loading the original.
+                        self.do_load_floppy(driveidx, path, wp);
+                    }
+                }
+                true
+            }
+            PromptChoice::Ask => {
+                self.pending_confirm = PendingConfirm::OfferMoofConversion {
+                    driveidx,
+                    original: path.to_path_buf(),
+                    moof_path: moof_path.clone(),
+                    moof_bytes,
+                    wp,
+                };
+                self.confirm_dialog.ask_with_remember(
+                    "Save MOOF copy?",
+                    format!(
+                        "This image format does not support writeback.\n\n\
+                         Convert to MOOF copy as:\n{}\n\n\
+                         so changes can be saved back to disk?\n\
+                         (original image will be preserved)",
+                        moof_path.display()
+                    ),
+                    vec![
+                        "Convert to MOOF".into(),
+                        "Load original".into(),
+                        "Cancel".into(),
+                    ],
+                    "Remember my choice",
+                );
+                true
+            }
+            PromptChoice::Never => unreachable!(),
         }
     }
 
@@ -2981,6 +3096,35 @@ impl eframe::App for SnowGui {
                     }
                     if answer.remember {
                         self.settings.writeback_mode = if enable {
+                            PromptChoice::Always
+                        } else {
+                            PromptChoice::Never
+                        };
+                        self.settings.save();
+                    }
+                }
+                PendingConfirm::OfferMoofConversion {
+                    driveidx,
+                    original,
+                    moof_path,
+                    moof_bytes,
+                    wp,
+                } => {
+                    match answer.button {
+                        0 => match std::fs::write(&moof_path, &moof_bytes) {
+                            Ok(()) => self.do_load_floppy(driveidx, &moof_path, wp),
+                            Err(e) => self.show_error(&format!(
+                                "Could not save '{}': {}",
+                                moof_path.display(),
+                                e
+                            )),
+                        },
+                        1 => self.do_load_floppy(driveidx, &original, wp),
+                        _ => {} // Cancel
+                    }
+                    // Cancel never persists a remembered choice.
+                    if answer.remember && answer.button != 2 {
+                        self.settings.convert_to_moof_mode = if answer.button == 0 {
                             PromptChoice::Always
                         } else {
                             PromptChoice::Never

--- a/frontend_egui/src/app.rs
+++ b/frontend_egui/src/app.rs
@@ -1619,6 +1619,8 @@ impl SnowGui {
                     "{} Floppy #{}: {}",
                     if d.ejected {
                         egui_material_icons::icons::ICON_EJECT
+                    } else if d.writeback_enabled {
+                        egui_material_icons::icons::ICON_AUTORENEW
                     } else if !d.ejected && d.dirty {
                         egui_material_icons::icons::ICON_SAVE_AS
                     } else {
@@ -1675,6 +1677,23 @@ impl SnowGui {
                         self.emu.reload_floppy(i);
                     }
                     ui.checkbox(&mut self.floppy_dialog_wp, "Mount write-protected");
+                    {
+                        let mut wb = d.writeback_enabled;
+                        let resp = ui.add_enabled(
+                            d.writeback_supported,
+                            egui::Checkbox::new(&mut wb, "Auto-save changes (writeback)"),
+                        );
+                        if d.writeback_supported {
+                            resp.on_hover_text(
+                                "When enabled, the image is written back to its source file.",
+                            );
+                        } else {
+                            resp.on_hover_text("Writeback only supported for MOOF files");
+                        }
+                        if wb != d.writeback_enabled {
+                            self.emu.set_floppy_writeback(i, wb);
+                        }
+                    }
                     ui.separator();
                     if ui
                         .add_enabled(!d.ejected && d.dirty, egui::Button::new("Save image..."))

--- a/frontend_egui/src/app.rs
+++ b/frontend_egui/src/app.rs
@@ -102,7 +102,7 @@ enum PendingConfirm {
     /// A writeback-capable image was just loaded into a drive.
     /// Button indices: 0 = enable writeback, 1 = leave disabled.
     /// 'Remember' enabled.
-    Writeback { driveidx: usize },
+    Writeback { driveidx: usize, path: PathBuf },
     /// User picked an image whose format has no writer and no MOOF sibling
     /// exists. Offer to save them as a sibling file.
     /// Button indices: 0 = save MOOF and load it, 1 = load original, 2 = cancel.
@@ -1214,6 +1214,19 @@ impl SnowGui {
                 });
                 if ui
                     .checkbox(
+                        &mut self.settings.backup_on_writeback,
+                        "Back up floppy image before enabling writeback",
+                    )
+                    .on_hover_text(
+                        "Before writeback is enabled for a floppy image, copy it to a \
+                         timestamped sibling file in the same directory.",
+                    )
+                    .clicked()
+                {
+                    self.settings.save();
+                }
+                if ui
+                    .checkbox(
                         &mut self.settings.fastforward_limit_enabled,
                         "Limit fast-forward speed",
                     )
@@ -2184,11 +2197,14 @@ impl SnowGui {
         }
         match self.settings.writeback_mode {
             PromptChoice::Always => {
-                self.emu.set_floppy_writeback(driveidx, true);
+                self.floppy_enable_writeback(driveidx, path);
             }
             PromptChoice::Never => {}
             PromptChoice::Ask => {
-                self.pending_confirm = PendingConfirm::Writeback { driveidx };
+                self.pending_confirm = PendingConfirm::Writeback {
+                    driveidx,
+                    path: path.to_path_buf(),
+                };
                 self.confirm_dialog.ask_with_remember(
                     "Enable floppy writeback?",
                     "This image supports writeback (saving changes back to \
@@ -2199,6 +2215,39 @@ impl SnowGui {
                 );
             }
         }
+    }
+
+    fn floppy_enable_writeback(&mut self, driveidx: usize, path: &Path) {
+        if self.settings.backup_on_writeback
+            && let Err(e) = Self::floppy_backup_image(path)
+        {
+            self.show_error(&format!("Could not back up '{}': {}", path.display(), e));
+            return;
+        }
+        self.emu.set_floppy_writeback(driveidx, true);
+    }
+
+    fn floppy_backup_image(path: &Path) -> std::io::Result<()> {
+        let parent = path.parent().unwrap_or_else(|| Path::new("."));
+        let stem = path.file_stem().unwrap_or_default().to_string_lossy();
+        let ext = path
+            .extension()
+            .map(|e| e.to_string_lossy().into_owned())
+            .unwrap_or_default();
+        let ts = chrono::Local::now().format("%Y-%m-%d %H%M%S");
+        let mut backup_name = format!("{}-bak {}", stem, ts);
+        if !ext.is_empty() {
+            backup_name.push('.');
+            backup_name.push_str(&ext);
+        }
+        let backup_path = parent.join(backup_name);
+        std::fs::copy(path, &backup_path)?;
+        log::info!(
+            "Backed up '{}' to '{}'",
+            path.display(),
+            backup_path.display()
+        );
+        Ok(())
     }
 
     /// Like [`Self::request_load_floppy`] but picks the first free drive.
@@ -3089,10 +3138,10 @@ impl eframe::App for SnowGui {
                         self.do_load_floppy(driveidx, &p, wp);
                     }
                 }
-                PendingConfirm::Writeback { driveidx } => {
+                PendingConfirm::Writeback { driveidx, path } => {
                     let enable = answer.button == 0;
                     if enable {
-                        self.emu.set_floppy_writeback(driveidx, true);
+                        self.floppy_enable_writeback(driveidx, &path);
                     }
                     if answer.remember {
                         self.settings.writeback_mode = if enable {

--- a/frontend_egui/src/app.rs
+++ b/frontend_egui/src/app.rs
@@ -712,6 +712,24 @@ impl SnowGui {
                         }
                     });
                 }
+                ui.separator();
+                ui.menu_button("Map alternate Cmd key", |ui| {
+                    ui.radio_value(
+                        &mut self.workspace.cmd_key_mapping,
+                        CmdKeyMapping::Disabled,
+                        "Disabled",
+                    );
+                    ui.radio_value(
+                        &mut self.workspace.cmd_key_mapping,
+                        CmdKeyMapping::RightAlt,
+                        "Right Alt",
+                    );
+                    ui.radio_value(
+                        &mut self.workspace.cmd_key_mapping,
+                        CmdKeyMapping::RightCtrl,
+                        "Right Ctrl",
+                    );
+                });
             });
 
             ui.menu_button("State", |ui| {
@@ -918,6 +936,157 @@ impl SnowGui {
             });
             ui.menu_button("Options", |ui| {
                 ui.set_min_width(Self::SUBMENU_WIDTH);
+                if ui
+                    .checkbox(
+                        &mut self.settings.native_file_dialogs,
+                        "Native file dialogs",
+                    )
+                    .clicked()
+                {
+                    self.settings.save();
+                }
+                if ui
+                    .checkbox(
+                        &mut self.settings.hide_mode_toasts,
+                        "Hide fullscreen/zen mode toasts",
+                    )
+                    .clicked()
+                {
+                    self.settings.save();
+                }
+                ui.separator();
+                ui.menu_button("Input", |ui| {
+                    ui.set_min_width(Self::SUBMENU_WIDTH);
+                    if ui
+                        .checkbox(
+                            &mut self.settings.auto_relative_mouse_fullscreen,
+                            "Use relative mouse in fullscreen",
+                        )
+                        .on_hover_text(
+                            "Automatically switch to relative mouse mode when entering fullscreen",
+                        )
+                        .clicked()
+                    {
+                        self.settings.save();
+                    }
+                });
+                ui.menu_button("Speed", |ui| {
+                    ui.set_min_width(Self::SUBMENU_WIDTH);
+                    if ui
+                        .checkbox(
+                            &mut self.settings.fastforward_limit_enabled,
+                            "Limit fast-forward speed",
+                        )
+                        .on_hover_text("Limits the speed increase when using fast-forward mode")
+                        .clicked()
+                    {
+                        self.settings.save();
+                        if self.ff_on && self.dynamic_ff_input_time.is_none() {
+                            self.emu.set_speed(self.ff_target_speed());
+                        }
+                    }
+                    ui.add_enabled_ui(self.settings.fastforward_limit_enabled, |ui| {
+                        if ui
+                            .add(
+                                egui::Slider::new(
+                                    &mut self.settings.fastforward_limit,
+                                    1.0_f64..=10.0_f64,
+                                )
+                                .step_by(0.5)
+                                .suffix("x"),
+                            )
+                            .changed()
+                        {
+                            self.settings.save();
+                            if self.ff_on && self.dynamic_ff_input_time.is_none() {
+                                self.emu.set_speed(self.ff_target_speed());
+                            }
+                        }
+                    });
+                    if ui
+                        .checkbox(
+                            &mut self.settings.dynamic_fastforward,
+                            "Dynamic fast-forward",
+                        )
+                        .on_hover_text(
+                            "Pauses fast-forward mode momentarily on keyboard/mouse input \
+                            to make controlling the system easier",
+                        )
+                        .clicked()
+                    {
+                        self.settings.save();
+                        if !self.settings.dynamic_fastforward
+                            && self.dynamic_ff_input_time.is_some()
+                        {
+                            // Was disabled mid-slowdown, resume FF immediately
+                            self.emu.set_speed(self.ff_target_speed());
+                            self.dynamic_ff_input_time = None;
+                        }
+                    }
+                });
+                ui.menu_button("Floppy", |ui| {
+                    ui.set_min_width(Self::SUBMENU_WIDTH);
+                    ui.menu_button("Writeback", |ui| {
+                        ui.set_min_width(Self::SUBMENU_WIDTH);
+                        let prev = self.settings.writeback_mode;
+                        ui.radio_value(
+                            &mut self.settings.writeback_mode,
+                            PromptChoice::Ask,
+                            "Ask each time",
+                        );
+                        ui.radio_value(
+                            &mut self.settings.writeback_mode,
+                            PromptChoice::Always,
+                            "Always enable",
+                        );
+                        ui.radio_value(
+                            &mut self.settings.writeback_mode,
+                            PromptChoice::Never,
+                            "Never enable",
+                        );
+                        if self.settings.writeback_mode != prev {
+                            self.settings.save();
+                        }
+                    });
+                    ui.menu_button("Convert to MOOF", |ui| {
+                        ui.set_min_width(Self::SUBMENU_WIDTH);
+                        let prev = self.settings.convert_to_moof_mode;
+                        ui.radio_value(
+                            &mut self.settings.convert_to_moof_mode,
+                            PromptChoice::Ask,
+                            "Ask each time",
+                        );
+                        ui.radio_value(
+                            &mut self.settings.convert_to_moof_mode,
+                            PromptChoice::Always,
+                            "Always convert",
+                        );
+                        ui.radio_value(
+                            &mut self.settings.convert_to_moof_mode,
+                            PromptChoice::Never,
+                            "Never convert",
+                        );
+                        if self.settings.convert_to_moof_mode != prev {
+                            self.settings.save();
+                        }
+                    });
+                    if ui
+                        .checkbox(
+                            &mut self.settings.backup_on_writeback,
+                            "Back up floppy image before enabling writeback",
+                        )
+                        .on_hover_text(
+                            "Before writeback is enabled for a floppy image, copy it to a \
+                             timestamped sibling file in the same directory.",
+                        )
+                        .clicked()
+                    {
+                        self.settings.save();
+                    }
+                });
+            });
+            ui.menu_button("View", |ui| {
+                ui.set_min_width(Self::SUBMENU_WIDTH);
                 ui.menu_button("UI scale", |ui| {
                     ui.set_min_width(Self::SUBMENU_WIDTH);
                     for z in Self::ZOOM_FACTORS {
@@ -928,7 +1097,6 @@ impl SnowGui {
                 });
                 ui.separator();
                 if self.emu.is_initialized() {
-                    ui.strong("Viewport options");
                     ui.add(
                         egui::Slider::new(&mut self.framebuffer.scale, 0.5..=4.0)
                             .text("Display scale"),
@@ -1116,167 +1284,6 @@ impl SnowGui {
                     }
                     ui.separator();
                 }
-                ui.strong("Global settings");
-                ui.menu_button("Map alternate Cmd key", |ui| {
-                    ui.radio_value(
-                        &mut self.workspace.cmd_key_mapping,
-                        CmdKeyMapping::Disabled,
-                        "Disabled",
-                    );
-                    ui.radio_value(
-                        &mut self.workspace.cmd_key_mapping,
-                        CmdKeyMapping::RightAlt,
-                        "Right Alt",
-                    );
-                    ui.radio_value(
-                        &mut self.workspace.cmd_key_mapping,
-                        CmdKeyMapping::RightCtrl,
-                        "Right Ctrl",
-                    );
-                });
-                ui.checkbox(
-                    &mut self.workspace.disassembly_labels,
-                    "Show labels in disassembly",
-                );
-                if ui
-                    .checkbox(
-                        &mut self.settings.native_file_dialogs,
-                        "Native file dialogs",
-                    )
-                    .clicked()
-                {
-                    self.settings.save();
-                }
-                if ui
-                    .checkbox(
-                        &mut self.settings.hide_mode_toasts,
-                        "Hide fullscreen/zen mode toasts",
-                    )
-                    .clicked()
-                {
-                    self.settings.save();
-                }
-                if ui
-                    .checkbox(
-                        &mut self.settings.auto_relative_mouse_fullscreen,
-                        "Use relative mouse in fullscreen",
-                    )
-                    .on_hover_text(
-                        "Automatically switch to relative mouse mode when entering fullscreen",
-                    )
-                    .clicked()
-                {
-                    self.settings.save();
-                }
-                ui.menu_button("Floppy writeback", |ui| {
-                    ui.set_min_width(Self::SUBMENU_WIDTH);
-                    let prev = self.settings.writeback_mode;
-                    ui.radio_value(
-                        &mut self.settings.writeback_mode,
-                        PromptChoice::Ask,
-                        "Ask each time",
-                    );
-                    ui.radio_value(
-                        &mut self.settings.writeback_mode,
-                        PromptChoice::Always,
-                        "Always enable",
-                    );
-                    ui.radio_value(
-                        &mut self.settings.writeback_mode,
-                        PromptChoice::Never,
-                        "Never enable",
-                    );
-                    if self.settings.writeback_mode != prev {
-                        self.settings.save();
-                    }
-                });
-                ui.menu_button("Convert floppy images to MOOF", |ui| {
-                    ui.set_min_width(Self::SUBMENU_WIDTH);
-                    let prev = self.settings.convert_to_moof_mode;
-                    ui.radio_value(
-                        &mut self.settings.convert_to_moof_mode,
-                        PromptChoice::Ask,
-                        "Ask each time",
-                    );
-                    ui.radio_value(
-                        &mut self.settings.convert_to_moof_mode,
-                        PromptChoice::Always,
-                        "Always convert",
-                    );
-                    ui.radio_value(
-                        &mut self.settings.convert_to_moof_mode,
-                        PromptChoice::Never,
-                        "Never convert",
-                    );
-                    if self.settings.convert_to_moof_mode != prev {
-                        self.settings.save();
-                    }
-                });
-                if ui
-                    .checkbox(
-                        &mut self.settings.backup_on_writeback,
-                        "Back up floppy image before enabling writeback",
-                    )
-                    .on_hover_text(
-                        "Before writeback is enabled for a floppy image, copy it to a \
-                         timestamped sibling file in the same directory.",
-                    )
-                    .clicked()
-                {
-                    self.settings.save();
-                }
-                if ui
-                    .checkbox(
-                        &mut self.settings.fastforward_limit_enabled,
-                        "Limit fast-forward speed",
-                    )
-                    .on_hover_text("Limits the speed increase when using fast-forward mode")
-                    .clicked()
-                {
-                    self.settings.save();
-                    if self.ff_on && self.dynamic_ff_input_time.is_none() {
-                        self.emu.set_speed(self.ff_target_speed());
-                    }
-                }
-                ui.add_enabled_ui(self.settings.fastforward_limit_enabled, |ui| {
-                    if ui
-                        .add(
-                            egui::Slider::new(
-                                &mut self.settings.fastforward_limit,
-                                1.0_f64..=10.0_f64,
-                            )
-                            .step_by(0.5)
-                            .suffix("x"),
-                        )
-                        .changed()
-                    {
-                        self.settings.save();
-                        if self.ff_on && self.dynamic_ff_input_time.is_none() {
-                            self.emu.set_speed(self.ff_target_speed());
-                        }
-                    }
-                });
-                if ui
-                    .checkbox(
-                        &mut self.settings.dynamic_fastforward,
-                        "Dynamic fast-forward",
-                    )
-                    .on_hover_text(
-                        "Pauses fast-forward mode momentarily on keyboard/mouse input \
-                        to make controlling the system easier",
-                    )
-                    .clicked()
-                {
-                    self.settings.save();
-                    if !self.settings.dynamic_fastforward && self.dynamic_ff_input_time.is_some() {
-                        // Was disabled mid-slowdown, resume FF immediately
-                        self.emu.set_speed(self.ff_target_speed());
-                        self.dynamic_ff_input_time = None;
-                    }
-                }
-            });
-            ui.menu_button("View", |ui| {
-                ui.set_min_width(Self::SUBMENU_WIDTH);
                 if ui
                     .add_enabled(
                         self.emu.is_initialized(),
@@ -1298,6 +1305,10 @@ impl SnowGui {
                 ui.separator();
                 ui.checkbox(&mut self.workspace.log_open, "Log");
                 ui.checkbox(&mut self.workspace.disassembly_open, "Disassembly");
+                ui.checkbox(
+                    &mut self.workspace.disassembly_labels,
+                    "Show labels in disassembly",
+                );
                 ui.checkbox(
                     &mut self.workspace.instruction_history_open,
                     "Instruction history",

--- a/frontend_egui/src/app.rs
+++ b/frontend_egui/src/app.rs
@@ -6,7 +6,7 @@ use crate::dialogs::modelselect::{ModelSelectionDialog, ModelSelectionResult};
 use crate::emulator::EmulatorState;
 use crate::emulator::{EmulatorInitArgs, ScsiTargets};
 use crate::keymap::{char_to_keystroke, map_winit_keycode};
-use crate::settings::{AppSettings, PromptChoice};
+use crate::settings::{AppSettings, CmdKeyMapping, PromptChoice};
 use crate::uniform::{UNIFORM_ACTION, UniformAction};
 use crate::widgets::breakpoints::BreakpointsWidget;
 use crate::widgets::disassembly::DisassemblyWidget;
@@ -18,7 +18,7 @@ use crate::widgets::registers::RegistersWidget;
 use crate::widgets::systrap_history::SystrapHistoryWidget;
 use crate::widgets::terminal::TerminalWidget;
 use crate::widgets::watchpoints::WatchpointsWidget;
-use crate::workspace::{CmdKeyMapping, FramebufferMode, Workspace};
+use crate::workspace::{FramebufferMode, Workspace};
 use snow_core::bus::Address;
 use snow_core::emulator::MouseMode;
 use snow_core::emulator::comm::{EmulatorSpeed, UserMessageType};
@@ -712,24 +712,6 @@ impl SnowGui {
                         }
                     });
                 }
-                ui.separator();
-                ui.menu_button("Map alternate Cmd key", |ui| {
-                    ui.radio_value(
-                        &mut self.workspace.cmd_key_mapping,
-                        CmdKeyMapping::Disabled,
-                        "Disabled",
-                    );
-                    ui.radio_value(
-                        &mut self.workspace.cmd_key_mapping,
-                        CmdKeyMapping::RightAlt,
-                        "Right Alt",
-                    );
-                    ui.radio_value(
-                        &mut self.workspace.cmd_key_mapping,
-                        CmdKeyMapping::RightCtrl,
-                        "Right Ctrl",
-                    );
-                });
             });
 
             ui.menu_button("State", |ui| {
@@ -969,6 +951,27 @@ impl SnowGui {
                     {
                         self.settings.save();
                     }
+                    ui.menu_button("Map alternate Cmd key", |ui| {
+                        let prev = self.settings.cmd_key_mapping;
+                        ui.radio_value(
+                            &mut self.settings.cmd_key_mapping,
+                            CmdKeyMapping::Disabled,
+                            "Disabled",
+                        );
+                        ui.radio_value(
+                            &mut self.settings.cmd_key_mapping,
+                            CmdKeyMapping::RightAlt,
+                            "Right Alt",
+                        );
+                        ui.radio_value(
+                            &mut self.settings.cmd_key_mapping,
+                            CmdKeyMapping::RightCtrl,
+                            "Right Ctrl",
+                        );
+                        if self.settings.cmd_key_mapping != prev {
+                            self.settings.save();
+                        }
+                    });
                 });
                 ui.menu_button("Speed", |ui| {
                     ui.set_min_width(Self::SUBMENU_WIDTH);
@@ -2305,7 +2308,7 @@ impl SnowGui {
                         continue;
                     }
 
-                    if let Some(k) = map_winit_keycode(kc, self.workspace.cmd_key_mapping) {
+                    if let Some(k) = map_winit_keycode(kc, self.settings.cmd_key_mapping) {
                         self.emu.update_key(k, state.is_pressed());
                         if state.is_pressed() {
                             self.on_user_input();

--- a/frontend_egui/src/app.rs
+++ b/frontend_egui/src/app.rs
@@ -1,4 +1,5 @@
 use crate::dialogs::about::AboutDialog;
+use crate::dialogs::confirm::ConfirmDialog;
 use crate::dialogs::diskimage::{DiskImageDialog, DiskImageDialogResult};
 use crate::dialogs::filedialog::SnowFileDialog;
 use crate::dialogs::modelselect::{ModelSelectionDialog, ModelSelectionResult};
@@ -81,6 +82,23 @@ enum FloppyDialogTarget {
     Drive(usize),
     /// Save this image to a file (invalid on load)
     Image(Box<FloppyImage>),
+}
+
+/// In-flight question awaiting an answer from [`ConfirmDialog`]. Each
+/// variant records the data needed to dispatch the chosen action when
+/// the user picks a button.
+#[derive(Default)]
+enum PendingConfirm {
+    #[default]
+    None,
+    /// User picked a non-MOOF floppy and a sibling `.moof` was found.
+    /// Button indices: 0 = load MOOF, 1 = load original, 2 = cancel.
+    MoofVariant {
+        driveidx: usize,
+        original: PathBuf,
+        moof: PathBuf,
+        wp: bool,
+    },
 }
 
 #[derive(Clone)]
@@ -183,6 +201,8 @@ pub struct SnowGui {
 
     error_dialog_open: bool,
     error_string: String,
+    confirm_dialog: ConfirmDialog,
+    pending_confirm: PendingConfirm,
     ui_active: bool,
     last_running: bool,
 
@@ -425,6 +445,8 @@ impl SnowGui {
 
             error_dialog_open: false,
             error_string: String::new(),
+            confirm_dialog: ConfirmDialog::new(),
+            pending_confirm: PendingConfirm::None,
             ui_active: true,
             last_running: false,
 
@@ -494,7 +516,7 @@ impl SnowGui {
             if app.emu.is_initialized() {
                 for floppy_path in floppies {
                     let path = Path::new(floppy_path);
-                    if !app.emu.load_floppy_firstfree(path) {
+                    if !app.request_load_floppy_firstfree(path) {
                         log::warn!(
                             "Failed to load floppy '{}': no available drives",
                             path.display()
@@ -1613,7 +1635,10 @@ impl SnowGui {
     }
 
     fn draw_menu_floppies(&mut self, ui: &mut egui::Ui) {
-        for (i, d) in (0..3).filter_map(|i| self.emu.get_fdd_status(i).map(|d| (i, d))) {
+        let fdds: Vec<(usize, _)> = (0..3)
+            .filter_map(|i| self.emu.get_fdd_status(i).cloned().map(|d| (i, d)))
+            .collect();
+        for (i, d) in fdds {
             ui.menu_button(
                 format!(
                     "{} Floppy #{}: {}",
@@ -1659,8 +1684,7 @@ impl SnowGui {
                             self.settings.get_recent_floppy_images_for_display()
                         {
                             if ui.button(format!("{}: {}", idx, display_name)).clicked() {
-                                self.emu.load_floppy(i, &path, false);
-                                self.settings.add_recent_floppy_image(&path);
+                                self.request_load_floppy(i, &path, false);
                             }
                         }
                         if self.settings.recent_floppy_images.is_empty() {
@@ -1953,6 +1977,72 @@ impl SnowGui {
         self.error_string = text.to_string();
     }
 
+    /// If `path` is not already a MOOF and a sibling file with the same
+    /// stem and a case-insensitive `.moof` extension exists, returns its
+    /// path.
+    fn moof_sibling(path: &Path) -> Option<PathBuf> {
+        if path
+            .extension()
+            .is_some_and(|e| e.eq_ignore_ascii_case("moof"))
+        {
+            return None;
+        }
+        let stem = path.file_stem()?;
+        let parent = path.parent()?;
+        std::fs::read_dir(parent)
+            .ok()?
+            .flatten()
+            .map(|e| e.path())
+            .find(|p| {
+                p.file_stem() == Some(stem)
+                    && p.extension()
+                        .is_some_and(|e| e.eq_ignore_ascii_case("moof"))
+            })
+    }
+
+    /// Loads `path` into `driveidx`. If a sibling `.moof` is found alongside
+    /// a non-MOOF image, prompts the user to choose. Updates the recent
+    /// images list with whichever path actually loads.
+    pub fn request_load_floppy(&mut self, driveidx: usize, path: &Path, wp: bool) {
+        if let Some(moof) = Self::moof_sibling(path) {
+            self.pending_confirm = PendingConfirm::MoofVariant {
+                driveidx,
+                original: path.to_path_buf(),
+                moof: moof.clone(),
+                wp,
+            };
+            self.confirm_dialog.ask(
+                "Load MOOF image instead?",
+                format!(
+                    "A MOOF version of this image was found alongside it:\n\n{}\n\n\
+                     MOOF supports writing back to the source file and is preferred.\n\
+                     Load it instead?",
+                    moof.display()
+                ),
+                vec!["Load MOOF".into(), "Load original".into(), "Cancel".into()],
+            );
+        } else {
+            self.emu.load_floppy(driveidx, path, wp);
+            self.settings.add_recent_floppy_image(path);
+        }
+    }
+
+    /// Like [`Self::request_load_floppy`] but picks the first free drive.
+    /// Returns `false` if no drive is available; otherwise the load may be
+    /// gated on a confirmation dialog.
+    pub fn request_load_floppy_firstfree(&mut self, path: &Path) -> bool {
+        for i in 0..3 {
+            if let Some(d) = self.emu.get_fdd_status(i)
+                && d.present
+                && d.ejected
+            {
+                self.request_load_floppy(i, path, false);
+                return true;
+            }
+        }
+        false
+    }
+
     fn poll_winit_events(&mut self, ctx: &egui::Context) {
         if self.wev_recv.is_empty() {
             return;
@@ -2141,9 +2231,9 @@ impl SnowGui {
                 model,
             );
 
-            if let Some(floppy_path) = self.workspace.get_floppy_images().first()
+            if let Some(floppy_path) = self.workspace.get_floppy_images().first().cloned()
                 && floppy_path.exists()
-                && !self.emu.load_floppy_firstfree(floppy_path)
+                && !self.request_load_floppy_firstfree(&floppy_path)
             {
                 self.show_error(&format!(
                     "Cannot load floppy image: no free drive for {:?}",
@@ -2589,7 +2679,7 @@ impl SnowGui {
                     return;
                 };
                 if snow_floppy::loaders::Autodetect::detect(&image).is_ok() {
-                    if !self.emu.load_floppy_firstfree(path) {
+                    if !self.request_load_floppy_firstfree(path) {
                         self.toasts.add(
                             Toast::new()
                                 .text("Cannot load floppy image: no free drive")
@@ -2805,6 +2895,31 @@ impl eframe::App for SnowGui {
         self.about_dialog.update(ctx);
         self.ui_active &= !self.about_dialog.is_open();
 
+        // Confirmation dialog
+        self.confirm_dialog.update(ctx);
+        self.ui_active &= !self.confirm_dialog.is_open();
+        if let Some(idx) = self.confirm_dialog.take_answer() {
+            match std::mem::take(&mut self.pending_confirm) {
+                PendingConfirm::MoofVariant {
+                    driveidx,
+                    original,
+                    moof,
+                    wp,
+                } => {
+                    let target = match idx {
+                        0 => Some(moof),     // Load MOOF
+                        1 => Some(original), // Load original
+                        _ => None,           // Cancel
+                    };
+                    if let Some(p) = target {
+                        self.emu.load_floppy(driveidx, &p, wp);
+                        self.settings.add_recent_floppy_image(&p);
+                    }
+                }
+                PendingConfirm::None => {}
+            }
+        }
+
         // Update snowflakes
         self.update_snowflakes(ctx.content_rect().size());
 
@@ -2909,8 +3024,8 @@ impl eframe::App for SnowGui {
                     let FloppyDialogTarget::Drive(driveidx) = self.floppy_dialog_target else {
                         unreachable!()
                     };
-                    self.emu.load_floppy(driveidx, &path, self.floppy_dialog_wp);
-                    self.settings.add_recent_floppy_image(&path);
+                    let wp = self.floppy_dialog_wp;
+                    self.request_load_floppy(driveidx, &path, wp);
                 }
                 DialogMode::SaveFile => {
                     if !path

--- a/frontend_egui/src/app.rs
+++ b/frontend_egui/src/app.rs
@@ -6,7 +6,7 @@ use crate::dialogs::modelselect::{ModelSelectionDialog, ModelSelectionResult};
 use crate::emulator::EmulatorState;
 use crate::emulator::{EmulatorInitArgs, ScsiTargets};
 use crate::keymap::{char_to_keystroke, map_winit_keycode};
-use crate::settings::AppSettings;
+use crate::settings::{AppSettings, PromptChoice};
 use crate::uniform::{UNIFORM_ACTION, UniformAction};
 use crate::widgets::breakpoints::BreakpointsWidget;
 use crate::widgets::disassembly::DisassemblyWidget;
@@ -99,6 +99,10 @@ enum PendingConfirm {
         moof: PathBuf,
         wp: bool,
     },
+    /// A writeback-capable image was just loaded into a drive.
+    /// Button indices: 0 = enable writeback, 1 = leave disabled.
+    /// 'Remember' enabled.
+    Writeback { driveidx: usize },
 }
 
 #[derive(Clone)]
@@ -386,7 +390,7 @@ impl SnowGui {
             floppy_dialog: SnowFileDialog::new()
                 .add_filter(
                     "Floppy images",
-                    &snow_floppy::loaders::ImageType::EXTENSIONS,
+                    &snow_floppy::loaders::ImageType::all_extensions(),
                 )
                 .add_save_extension("Applesauce MOOF", "moof")
                 .default_save_extension("Applesauce MOOF")
@@ -1154,6 +1158,28 @@ impl SnowGui {
                 {
                     self.settings.save();
                 }
+                ui.menu_button("Floppy writeback", |ui| {
+                    ui.set_min_width(Self::SUBMENU_WIDTH);
+                    let prev = self.settings.writeback_mode;
+                    ui.radio_value(
+                        &mut self.settings.writeback_mode,
+                        PromptChoice::Ask,
+                        "Ask each time",
+                    );
+                    ui.radio_value(
+                        &mut self.settings.writeback_mode,
+                        PromptChoice::Always,
+                        "Always enable",
+                    );
+                    ui.radio_value(
+                        &mut self.settings.writeback_mode,
+                        PromptChoice::Never,
+                        "Never enable",
+                    );
+                    if self.settings.writeback_mode != prev {
+                        self.settings.save();
+                    }
+                });
                 if ui
                     .checkbox(
                         &mut self.settings.fastforward_limit_enabled,
@@ -2022,8 +2048,41 @@ impl SnowGui {
                 vec!["Load MOOF".into(), "Load original".into(), "Cancel".into()],
             );
         } else {
-            self.emu.load_floppy(driveidx, path, wp);
-            self.settings.add_recent_floppy_image(path);
+            self.do_load_floppy(driveidx, path, wp);
+        }
+    }
+
+    fn do_load_floppy(&mut self, driveidx: usize, path: &Path, wp: bool) {
+        self.emu.load_floppy(driveidx, path, wp);
+        self.settings.add_recent_floppy_image(path);
+        self.apply_writeback_policy(driveidx, path);
+    }
+
+    /// Decides what to do about writeback for an image that was just
+    /// loaded into `driveidx`. Honours [`AppSettings::writeback_mode`].
+    fn apply_writeback_policy(&mut self, driveidx: usize, path: &Path) {
+        let writeback_capable = path
+            .extension()
+            .is_some_and(snow_floppy::loaders::extension_has_saver);
+        if !writeback_capable {
+            return;
+        }
+        match self.settings.writeback_mode {
+            PromptChoice::Always => {
+                self.emu.set_floppy_writeback(driveidx, true);
+            }
+            PromptChoice::Never => {}
+            PromptChoice::Ask => {
+                self.pending_confirm = PendingConfirm::Writeback { driveidx };
+                self.confirm_dialog.ask_with_remember(
+                    "Enable floppy writeback?",
+                    "This image supports writeback (saving changes back to \
+                     its source file as you make them).\n\n\
+                     Enable writeback for this image?",
+                    vec!["Enable".into(), "Don't enable".into()],
+                    "Remember my choice",
+                );
+            }
         }
     }
 
@@ -2667,7 +2726,7 @@ impl SnowGui {
         };
 
         // Try to detect and load floppy images
-        if snow_floppy::loaders::ImageType::EXTENSIONS
+        if snow_floppy::loaders::ImageType::all_extensions()
             .into_iter()
             .any(|s| ext.eq_ignore_ascii_case(s))
         {
@@ -2898,7 +2957,7 @@ impl eframe::App for SnowGui {
         // Confirmation dialog
         self.confirm_dialog.update(ctx);
         self.ui_active &= !self.confirm_dialog.is_open();
-        if let Some(idx) = self.confirm_dialog.take_answer() {
+        if let Some(answer) = self.confirm_dialog.take_answer() {
             match std::mem::take(&mut self.pending_confirm) {
                 PendingConfirm::MoofVariant {
                     driveidx,
@@ -2906,14 +2965,27 @@ impl eframe::App for SnowGui {
                     moof,
                     wp,
                 } => {
-                    let target = match idx {
+                    let target = match answer.button {
                         0 => Some(moof),     // Load MOOF
                         1 => Some(original), // Load original
                         _ => None,           // Cancel
                     };
                     if let Some(p) = target {
-                        self.emu.load_floppy(driveidx, &p, wp);
-                        self.settings.add_recent_floppy_image(&p);
+                        self.do_load_floppy(driveidx, &p, wp);
+                    }
+                }
+                PendingConfirm::Writeback { driveidx } => {
+                    let enable = answer.button == 0;
+                    if enable {
+                        self.emu.set_floppy_writeback(driveidx, true);
+                    }
+                    if answer.remember {
+                        self.settings.writeback_mode = if enable {
+                            PromptChoice::Always
+                        } else {
+                            PromptChoice::Never
+                        };
+                        self.settings.save();
                     }
                 }
                 PendingConfirm::None => {}

--- a/frontend_egui/src/dialogs/confirm.rs
+++ b/frontend_egui/src/dialogs/confirm.rs
@@ -1,5 +1,14 @@
 use eframe::egui;
 
+/// Result of a confirmation dialog interaction.
+pub struct ConfirmAnswer {
+    /// Index of the clicked button (matching the order passed to `ask`).
+    pub button: usize,
+    /// True if the optional "remember" checkbox was ticked. Always false
+    /// when the dialog was opened without a remember label.
+    pub remember: bool,
+}
+
 /// Generic modal yes/no/N-choice question dialog.
 pub struct ConfirmDialog {
     state: Option<State>,
@@ -9,6 +18,9 @@ struct State {
     title: String,
     body: String,
     buttons: Vec<String>,
+    /// When `Some`, a checkbox with this label is shown above the buttons.
+    remember_label: Option<String>,
+    remember: bool,
     answer: Option<usize>,
 }
 
@@ -20,10 +32,35 @@ impl ConfirmDialog {
     /// Opens the dialog with the given title, body and button labels.
     /// Replaces any active question.
     pub fn ask(&mut self, title: impl Into<String>, body: impl Into<String>, buttons: Vec<String>) {
+        self.open(title, body, buttons, None);
+    }
+
+    /// Opens the dialog with an additional "remember" checkbox above the
+    /// buttons. The checkbox state is returned alongside the button index
+    /// in [`ConfirmAnswer::remember`].
+    pub fn ask_with_remember(
+        &mut self,
+        title: impl Into<String>,
+        body: impl Into<String>,
+        buttons: Vec<String>,
+        remember_label: impl Into<String>,
+    ) {
+        self.open(title, body, buttons, Some(remember_label.into()));
+    }
+
+    fn open(
+        &mut self,
+        title: impl Into<String>,
+        body: impl Into<String>,
+        buttons: Vec<String>,
+        remember_label: Option<String>,
+    ) {
         self.state = Some(State {
             title: title.into(),
             body: body.into(),
             buttons,
+            remember_label,
+            remember: false,
             answer: None,
         });
     }
@@ -46,6 +83,10 @@ impl ConfirmDialog {
             ui.add_space(8.0);
             ui.label(&state.body);
             ui.add_space(12.0);
+            if let Some(label) = state.remember_label.as_deref() {
+                ui.checkbox(&mut state.remember, label);
+                ui.add_space(4.0);
+            }
             ui.separator();
             ui.add_space(8.0);
             ui.horizontal(|ui| {
@@ -58,13 +99,14 @@ impl ConfirmDialog {
         });
     }
 
-    /// Returns the index of the clicked button (matching the order passed
-    /// to [`Self::ask`]) and closes the dialog. Returns `None` if no
-    /// answer yet.
-    pub fn take_answer(&mut self) -> Option<usize> {
-        let answer = self.state.as_ref()?.answer?;
+    /// Returns the user's choice and closes the dialog. Returns `None`
+    /// while the dialog is still awaiting a click.
+    pub fn take_answer(&mut self) -> Option<ConfirmAnswer> {
+        let state = self.state.as_ref()?;
+        let button = state.answer?;
+        let remember = state.remember;
         self.state = None;
-        Some(answer)
+        Some(ConfirmAnswer { button, remember })
     }
 }
 

--- a/frontend_egui/src/dialogs/confirm.rs
+++ b/frontend_egui/src/dialogs/confirm.rs
@@ -1,0 +1,75 @@
+use eframe::egui;
+
+/// Generic modal yes/no/N-choice question dialog.
+pub struct ConfirmDialog {
+    state: Option<State>,
+}
+
+struct State {
+    title: String,
+    body: String,
+    buttons: Vec<String>,
+    answer: Option<usize>,
+}
+
+impl ConfirmDialog {
+    pub fn new() -> Self {
+        Self { state: None }
+    }
+
+    /// Opens the dialog with the given title, body and button labels.
+    /// Replaces any active question.
+    pub fn ask(&mut self, title: impl Into<String>, body: impl Into<String>, buttons: Vec<String>) {
+        self.state = Some(State {
+            title: title.into(),
+            body: body.into(),
+            buttons,
+            answer: None,
+        });
+    }
+
+    pub fn is_open(&self) -> bool {
+        self.state.as_ref().is_some_and(|s| s.answer.is_none())
+    }
+
+    pub fn update(&mut self, ctx: &egui::Context) {
+        let Some(state) = self.state.as_mut() else {
+            return;
+        };
+        if state.answer.is_some() {
+            return;
+        }
+
+        egui::Modal::new(egui::Id::new("ConfirmDialog")).show(ctx, |ui| {
+            ui.set_max_width(450.0);
+            ui.heading(&state.title);
+            ui.add_space(8.0);
+            ui.label(&state.body);
+            ui.add_space(12.0);
+            ui.separator();
+            ui.add_space(8.0);
+            ui.horizontal(|ui| {
+                for (idx, label) in state.buttons.iter().enumerate() {
+                    if ui.button(label).clicked() {
+                        state.answer = Some(idx);
+                    }
+                }
+            });
+        });
+    }
+
+    /// Returns the index of the clicked button (matching the order passed
+    /// to [`Self::ask`]) and closes the dialog. Returns `None` if no
+    /// answer yet.
+    pub fn take_answer(&mut self) -> Option<usize> {
+        let answer = self.state.as_ref()?.answer?;
+        self.state = None;
+        Some(answer)
+    }
+}
+
+impl Default for ConfirmDialog {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/frontend_egui/src/dialogs/mod.rs
+++ b/frontend_egui/src/dialogs/mod.rs
@@ -1,4 +1,5 @@
 pub mod about;
+pub mod confirm;
 pub mod diskimage;
 pub mod filedialog;
 pub mod modelselect;

--- a/frontend_egui/src/emulator.rs
+++ b/frontend_egui/src/emulator.rs
@@ -722,18 +722,6 @@ impl EmulatorState {
             .unwrap();
     }
 
-    /// Loads a floppy image from the specified path in the first free drive.
-    pub fn load_floppy_firstfree(&self, path: &Path) -> bool {
-        // Find a free floppy drive
-        for (i, d) in (0..3).filter_map(|i| self.get_fdd_status(i).map(|d| (i, d))) {
-            if d.present && d.ejected {
-                self.load_floppy(i, path, false);
-                return true;
-            }
-        }
-        false
-    }
-
     /// Loads the included toolbox floppy.
     pub fn load_toolbox_floppy(&self) -> bool {
         let Some(ref sender) = self.cmdsender else {

--- a/frontend_egui/src/emulator.rs
+++ b/frontend_egui/src/emulator.rs
@@ -803,6 +803,17 @@ impl EmulatorState {
             .unwrap();
     }
 
+    /// Toggles automatic writeback of a floppy drive's image to its source file.
+    pub fn set_floppy_writeback(&self, driveidx: usize, enabled: bool) {
+        let Some(ref sender) = self.cmdsender else {
+            return;
+        };
+
+        sender
+            .send(EmulatorCommand::SetFloppyWriteback(driveidx, enabled))
+            .unwrap();
+    }
+
     /// Loads a SCSI HDD image from the specified path.
     pub fn scsi_attach_hdd(&self, id: usize, path: &Path) {
         let Some(ref sender) = self.cmdsender else {

--- a/frontend_egui/src/keymap.rs
+++ b/frontend_egui/src/keymap.rs
@@ -1,4 +1,4 @@
-use crate::workspace::CmdKeyMapping;
+use crate::settings::CmdKeyMapping;
 use eframe::egui;
 use snow_core::keymap::Scancode;
 

--- a/frontend_egui/src/settings.rs
+++ b/frontend_egui/src/settings.rs
@@ -3,6 +3,19 @@ use egui_file_dialog::FileDialogStorage;
 use serde::{Deserialize, Serialize};
 use snow_core::mac::MacModel;
 use std::path::{Path, PathBuf};
+use strum::{Display, EnumIter};
+
+/// Generic tri-state preference for an automatic action.
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq, Default, Display, EnumIter)]
+pub enum PromptChoice {
+    /// Ask the user every time.
+    #[default]
+    Ask,
+    /// Always perform the action without asking.
+    Always,
+    /// Never perform the action and don't ask.
+    Never,
+}
 
 const MAX_RECENT_WORKSPACES: usize = 10;
 const MAX_RECENT_IMAGES: usize = 10;
@@ -31,6 +44,7 @@ pub struct AppSettings {
     pub fastforward_limit: f64,
     pub dynamic_fastforward: bool,
     pub auto_relative_mouse_fullscreen: bool,
+    pub writeback_mode: PromptChoice,
 }
 
 impl Default for AppSettings {
@@ -55,6 +69,7 @@ impl Default for AppSettings {
             fastforward_limit: 2.0,
             dynamic_fastforward: false,
             auto_relative_mouse_fullscreen: true,
+            writeback_mode: PromptChoice::default(),
         }
     }
 }

--- a/frontend_egui/src/settings.rs
+++ b/frontend_egui/src/settings.rs
@@ -46,6 +46,9 @@ pub struct AppSettings {
     pub auto_relative_mouse_fullscreen: bool,
     pub writeback_mode: PromptChoice,
     pub convert_to_moof_mode: PromptChoice,
+    /// When true, copy the loaded image to a timestamped sibling file
+    /// just before writeback is enabled for it.
+    pub backup_on_writeback: bool,
 }
 
 impl Default for AppSettings {
@@ -72,6 +75,7 @@ impl Default for AppSettings {
             auto_relative_mouse_fullscreen: true,
             writeback_mode: PromptChoice::default(),
             convert_to_moof_mode: PromptChoice::default(),
+            backup_on_writeback: false,
         }
     }
 }

--- a/frontend_egui/src/settings.rs
+++ b/frontend_egui/src/settings.rs
@@ -45,6 +45,7 @@ pub struct AppSettings {
     pub dynamic_fastforward: bool,
     pub auto_relative_mouse_fullscreen: bool,
     pub writeback_mode: PromptChoice,
+    pub convert_to_moof_mode: PromptChoice,
 }
 
 impl Default for AppSettings {
@@ -70,6 +71,7 @@ impl Default for AppSettings {
             dynamic_fastforward: false,
             auto_relative_mouse_fullscreen: true,
             writeback_mode: PromptChoice::default(),
+            convert_to_moof_mode: PromptChoice::default(),
         }
     }
 }

--- a/frontend_egui/src/settings.rs
+++ b/frontend_egui/src/settings.rs
@@ -17,6 +17,18 @@ pub enum PromptChoice {
     Never,
 }
 
+/// Mapping of a right modifier key to the Mac's Cmd key
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum CmdKeyMapping {
+    /// No remapping; right Alt = Option, right Ctrl = Control
+    Disabled,
+    /// Right Alt maps to Cmd
+    #[default]
+    RightAlt,
+    /// Right Ctrl maps to Cmd
+    RightCtrl,
+}
+
 const MAX_RECENT_WORKSPACES: usize = 10;
 const MAX_RECENT_IMAGES: usize = 10;
 
@@ -49,6 +61,8 @@ pub struct AppSettings {
     /// When true, copy the loaded image to a timestamped sibling file
     /// just before writeback is enabled for it.
     pub backup_on_writeback: bool,
+    /// How the right modifier key maps to the Mac's Cmd key
+    pub cmd_key_mapping: CmdKeyMapping,
 }
 
 impl Default for AppSettings {
@@ -76,6 +90,7 @@ impl Default for AppSettings {
             writeback_mode: PromptChoice::default(),
             convert_to_moof_mode: PromptChoice::default(),
             backup_on_writeback: false,
+            cmd_key_mapping: CmdKeyMapping::default(),
         }
     }
 }

--- a/frontend_egui/src/workspace.rs
+++ b/frontend_egui/src/workspace.rs
@@ -195,18 +195,6 @@ impl From<WorkspaceEthernetLinkType> for EthernetLinkType {
     }
 }
 
-/// Mapping of a right modifier key to the Mac's Cmd key
-#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq, Default)]
-pub enum CmdKeyMapping {
-    /// No remapping; right Alt = Option, right Ctrl = Control
-    Disabled,
-    /// Right Alt maps to Cmd
-    #[default]
-    RightAlt,
-    /// Right Ctrl maps to Cmd
-    RightCtrl,
-}
-
 /// A workspace representation which contains:
 /// * (Paths to) loaded assets
 /// * View configuration of the egui frontend
@@ -263,14 +251,6 @@ pub struct Workspace {
 
     /// Emulated model (None for autodetect)
     pub model: Option<MacModel>,
-
-    /// How the right modifier key maps to Cmd
-    #[serde(default)]
-    pub cmd_key_mapping: CmdKeyMapping,
-
-    /// Deprecated: use cmd_key_mapping
-    #[serde(skip_serializing, default)]
-    map_cmd_ralt: Option<bool>,
 
     /// Scaling algorithm in use
     pub scaling_algorithm: ScalingAlgorithm,
@@ -330,8 +310,6 @@ impl Default for Workspace {
             windows: HashMap::new(),
             init_args: EmulatorInitArgs::default(),
             model: None,
-            cmd_key_mapping: CmdKeyMapping::default(),
-            map_cmd_ralt: None,
             scaling_algorithm: ScalingAlgorithm::Linear,
             pause_on_state_load: false,
             shared_dir: None,
@@ -403,15 +381,6 @@ impl Workspace {
 
         for p in &mut result.floppy_images {
             p.after_deserialize(parent)?;
-        }
-
-        // Migrate old map_cmd_ralt bool to cmd_key_mapping enum
-        if let Some(v) = result.map_cmd_ralt {
-            result.cmd_key_mapping = if v {
-                CmdKeyMapping::RightAlt
-            } else {
-                CmdKeyMapping::Disabled
-            };
         }
 
         // Migrate old framebuffer positioning fields to new enum


### PR DESCRIPTION
This PR implements writeback for floppy images and mostly the UX that comes with it.

Snow can load a variety of image files, but only write MOOF files. Therefore, enabling writeback requires a MOOF file. Snow can try to find a sibling image file or convert the file for the user.

A few use case scenario's:
* User opens a .MOOF
  * Snow asks if they want to enable writeback. There is a 'Remember my choice' option, which can be changed in the Options menu.
* User opens a .DC42 (example) and there's a .MOOF next to it with the same name.
  * Snow asks if they would like to open the .MOOF, instead.
  * If the user agrees, Snow asks if they want to enable writeback. There is a 'Remember my choice' option, which can be changed in the Options menu.
  * If the user chooses not to load the sibling ('Load original'), the original image will be loaded and writeback will be unavailable.
* User opens a .DART (example) and there's NO .MOOF next to it with the same name.
  * Snow asks if they would like to convert the .DART to a MOOF and save it next to it. There is a 'Remember my choice' option, which can be changed in the Options menu.
  * If the user chooses to convert, Snow asks if they want to enable writeback. There is a 'Remember my choice' option, which can be changed in the Options menu.
  * If the user chooses not to convert ('Load original'), the original image will be loaded and writeback will be unavailable.

Some caveats:
 * Only MOOF is supported for writeback.
 * MOOF images with flux tracks are not supported for writeback (there's no flux write support, yet).
 * If an image is mounted as write-protected, Snow will not offer to convert or to enable writeback.

Additionally:
* Reorganized the global settings to all live in the Options menu.
* Moved 'Map alternate Cmd key' from a workspace to a global setting.
* Option to create a backup when enabling writeback for an image.