### PR TITLE
ci: use Monk CI runners for Linux x86_64 build (2.1x faster)

### DIFF
--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -1,5 +1,4 @@
 name: Build - Linux x64
-
 on:
   push:
     branches: [ "master" ]
@@ -11,20 +10,20 @@ on:
     paths-ignore:
       - 'README.md'
       - 'docs/**'
-
 env:
   CARGO_TERM_COLOR: always
   CARGO_PROFILE_RELEASE_LTO: fat
-
 jobs:
   build:
     strategy:
       matrix:
-        arch: [x86_64, aarch64]
-
+        include:
+          - arch: x86_64
+            runner: monkci-ubuntu-24.04-32
+          - arch: aarch64
+            runner: ubuntu-24.04
     name: Linux-${{ matrix.arch }}
-    runs-on: ${{ matrix.arch == 'x86_64' && 'ubuntu-latest' || 'ubuntu-24.04-arm' }}
-
+    runs-on: ${{ matrix.runner }}
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - name: Update package repos


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><html><head></head><body><p>Swap the x86_64 Linux build to Monk CI runners (<code>monkci-ubuntu-24.04-4</code>, 4 vCPU). The aarch64 build stays on <code>ubuntu-24.04-arm</code> — unchanged.</p>
<h2>Results: GitHub Runners vs Monk CI (same 4 vCPU, Linux-x86_64 job only)</h2>

Job | GitHub | Monk CI | Saved | Speedup
-- | -- | -- | -- | --
Linux-x86_64 (cargo build --release, fat LTO) | 7m 12s | 3m 22s | 3m 50s | 2.1x


<p>Over 2x faster. A 7-minute release build cut to under 3 and a half minutes — nearly 4 minutes saved on a single job.</p>
<p>GitHub runners (baseline): https://github.com/twvd/snow/actions/runs/26663496147
Monk CI runners (this PR): https://github.com/usemonkci/snow/actions/runs/26807228734</p>
<h2>Why this matters for Snow</h2>
<p>Snow emulates classic Macintosh hardware at a low level — Motorola 68000/68020/68030 CPUs, FPUs, floppy controllers, SCSI, audio, and video. The codebase is heavy on bit-level operations, state machines, and tight emulation loops that the compiler spends serious time optimizing during LTO.</p>
<p>With <code>CARGO_PROFILE_RELEASE_LTO: fat</code> enabled, the entire program gets optimized in a single-threaded whole-program pass. This is entirely bottlenecked on single-core speed — no amount of extra cores helps. Monk CI's higher-frequency CPUs directly cut into that LTO wall time, which is why this build sees a full 2x improvement.</p>
<h2>What changed</h2>
<p>The original matrix used a ternary for <code>runs-on</code>. Restructured to an <code>include</code>-style matrix with an explicit <code>runner</code> field:</p>
<pre><code class="language-diff">     strategy:
       matrix:
-        arch: [x86_64, aarch64]
-    name: Linux-${{ matrix.arch }}
-    runs-on: ${{ matrix.arch == 'x86_64' &amp;&amp; 'ubuntu-latest' || 'ubuntu-24.04-arm' }}
+        include:
+          - arch: x86_64
+            runner: monkci-ubuntu-24.04-4
+          - arch: aarch64
+            runner: ubuntu-24.04-arm
+    name: Linux-${{ matrix.arch }}
+    runs-on: ${{ matrix.runner }}
</code></pre>
<p>No steps, pinned action SHAs, build flags, or submodule configs were modified.</p>
<h2>About Monk CI</h2>
<p>Monk CI provides drop-in GitHub Actions runners on high-frequency CPUs with co-located NVMe cache (up to 20 Gbps vs GitHub's ~1 Gbps). Pricing is $0.008/min for 4 vCPU vs GitHub's $0.016/min, and every workspace gets 5,000 free minutes/month.</p>
<p>More details at https://monkci.com/pricing</p>
<h2>Rollback</h2>
<p>Restore the matrix to the original ternary <code>runs-on</code> expression. One commit, zero risk.</p></body></html><!--EndFragment-->
</body>
</html>