### PR TITLE
Fix misinformation about the CD lead-in

### DIFF
--- a/core/src/mac/scsi/cdrom/backends/cuesheet.rs
+++ b/core/src/mac/scsi/cdrom/backends/cuesheet.rs
@@ -195,10 +195,12 @@ struct SectorMapBuilder {
 impl SectorMapBuilder {
     fn new() -> Self {
         // Data files always start at time 00:02:00 (sector 150).
-        // This means there are 150 sectors located in the lead-in area which
-        // cannot be specified by the .bin/.cue format.
-        // These sectors are usually empty, but sometimes they contain various
-        // data such as CD-TEXT information.
+        // The preceding 150 sectors form the session pre-gap: sectors that are
+        // filled with blank data and only exist so the drive can reliably find
+        // the start of the data. These sectors cannot be represented in the
+        // .bin/.cue format.
+        // The session pre-gap is separate from the lead-in, which contains the
+        // table of contents and CD-TEXT.
         Self {
             abs_cursor: LBA_START_SECTOR,
             file_cursor: None,
@@ -603,7 +605,7 @@ impl CuesheetCdromBackend {
         let mut sessions = vec![SessionInfo {
             number: 1,
             disc_type: 0x00,
-            leadin: 0,
+            start: 0,
             leadout: LBA_START_SECTOR,
         }];
         let mut tracks = vec![];
@@ -693,9 +695,9 @@ impl CuesheetCdromBackend {
                     }
 
                     if !session_has_tracks {
-                        // Set the lead-in to 150 sectors before the first track
-                        // FIXME: lead-in might be set incorrectly if pregaps/postgaps are present...
-                        sessions.last_mut().unwrap().leadin =
+                        // Set the start to 150 sectors before the first track
+                        // FIXME: start might be set incorrectly if pregaps/postgaps are present...
+                        sessions.last_mut().unwrap().start =
                             sector_map.abs_cursor.saturating_sub(LBA_START_SECTOR);
                     }
 
@@ -733,7 +735,7 @@ impl CuesheetCdromBackend {
                                     sessions.push(SessionInfo {
                                         number: new_session,
                                         disc_type: 0x00,
-                                        leadin: last_session.leadout,
+                                        start: last_session.leadout,
                                         leadout: last_session.leadout,
                                     });
 
@@ -881,8 +883,8 @@ impl CdromBackend for CuesheetCdromBackend {
     }
 
     fn byte_len(&self) -> usize {
-        // To find the capacity, treat each sector (except the lead-in) as a block
-        // containing 2048 bytes.
+        // To find the capacity, treat each sector (except the session pre-gap) as a
+        // block containing 2048 bytes.
         // However, only sectors in a Data track in Mode 1 or Mode 2 Form 1 are readable
         // via `read_bytes`.
         let final_leadout = self

--- a/core/src/mac/scsi/cdrom/backends/iso.rs
+++ b/core/src/mac/scsi/cdrom/backends/iso.rs
@@ -22,7 +22,7 @@ impl IsoCdromBackend {
             session: SessionInfo {
                 number: 1,
                 disc_type: 0x00,
-                leadin: 0,
+                start: 0,
                 leadout: LBA_START_SECTOR + sector_count,
             },
             track: TrackInfo {

--- a/core/src/mac/scsi/cdrom/backends/windows_drive.rs
+++ b/core/src/mac/scsi/cdrom/backends/windows_drive.rs
@@ -186,7 +186,7 @@ fn read_formatted_toc(handle: HANDLE) -> Result<(Vec<SessionInfo>, Vec<TrackInfo
         vec![SessionInfo {
             number: 1,
             disc_type: 0x00,
-            leadin: 0,
+            start: 0,
             leadout,
         }],
         tracks,
@@ -255,7 +255,7 @@ fn read_full_toc(handle: HANDLE) -> Result<(Vec<SessionInfo>, Vec<TrackInfo>)> {
 
     let mut sessions = vec![];
     let mut tracks = vec![];
-    let mut next_leadin = 0;
+    let mut next_start = 0;
 
     for (i, desc) in descriptors.iter().enumerate() {
         let adr = desc._bitfield >> 4;
@@ -281,10 +281,10 @@ fn read_full_toc(handle: HANDLE) -> Result<(Vec<SessionInfo>, Vec<TrackInfo>)> {
                 sessions.push(SessionInfo {
                     number: (sessions.len() + 1).try_into().unwrap(),
                     disc_type: 0x00,
-                    leadin: next_leadin,
+                    start: next_start,
                     leadout,
                 });
-                next_leadin = leadout;
+                next_start = leadout;
             }
         }
 
@@ -304,13 +304,13 @@ fn read_full_toc(handle: HANDLE) -> Result<(Vec<SessionInfo>, Vec<TrackInfo>)> {
             0xA2 => {
                 // Start position of Lead-out
                 session.leadout = Msf::from_bytes(desc.Msf).to_sector();
-                if next_leadin < session.leadout {
-                    next_leadin = session.leadout;
+                if next_start < session.leadout {
+                    next_start = session.leadout;
                 }
             }
             0xB0 => {
                 // Start time of next possible program
-                next_leadin = Msf::from_bytes(desc.MsfExtra).to_sector();
+                next_start = Msf::from_bytes(desc.MsfExtra).to_sector();
             }
             0xC0 => (), // Start time of the first Lead-in Area of the disc (ignored)
             1..=99 => {

--- a/core/src/mac/scsi/cdrom/mod.rs
+++ b/core/src/mac/scsi/cdrom/mod.rs
@@ -35,11 +35,8 @@ use super::{
 
 // CD-ROM protocol Documentation:
 //
-// [MMC3]: <https://13thmonkey.org/documentation/SCSI/mmc3r10g.pdf>
 // [MMC4]: <https://13thmonkey.org/documentation/SCSI/mmc4r05a.pdf>
-// [MMC6]: <https://13thmonkey.org/documentation/SCSI/mmc6r02g.pdf>
-// [PIONEER]: <https://bitsavers.trailing-edge.com/pdf/pioneer/cdrom/OB-U0077C_CD-ROM_SCSI-2_Command_Set_V3.1_19970626.pdf>
-// [MBWIKI]: <https://wiki.musicbrainz.org/Disc_ID_Calculation>
+// [CDU541]: <https://bitsavers.trailing-edge.com/pdf/sony/cdrom/CDU541-25_AppleCD_150/Sony_CDU-541_SCSI_Interface_Manual_Mar1990.pdf>
 
 const RAW_SECTOR_LEN: usize = 2352;
 const TRACK_LEADOUT: u8 = 0xAA;
@@ -141,8 +138,8 @@ pub struct SessionInfo {
     number: u8,
     /// Value to put in Disc Type field ([MMC4] Table 448)
     disc_type: u8,
-    /// Absolute sector number of lead-in
-    leadin: u32,
+    /// Absolute sector number of the start of the program area
+    start: u32,
     /// Absolute sector number of lead-out
     leadout: u32,
 }
@@ -551,7 +548,7 @@ impl ScsiTargetCdrom {
                             result.extend_from_slice(
                                 // FIXME: It's unclear whether this should be BCD or binary.
                                 // It probably makes no difference.
-                                &Msf::from_sector(next_session.leadin)?.to_bytes(),
+                                &Msf::from_sector(next_session.start)?.to_bytes(),
                             ); // Start time of next possible program
                             result.push(2); // # of pointers in Mode 5
                             result.extend_from_slice(
@@ -567,10 +564,9 @@ impl ScsiTargetCdrom {
                             result.push(0);
                             result.push(0);
                             result.push(0); // Zero
-                            // FIXME: Weird Al actually puts 95:00:00 here? where does that come from?
-                            result.extend_from_slice(
-                                &Msf::from_sector(sessions.first().unwrap().leadin)?.to_bcd_bytes(),
-                            ); // Start time of the first Lead-in Area of the disc)
+                            // Weird Al (and other discs) put timecode 95:00:00 here, indicating the Start of the pre-groove.
+                            // (see [MMC4] 4.2.4.9.2 ATIP Time Codes)
+                            result.extend_from_slice(&Msf::new(95, 0, 0).to_bcd_bytes()); // Start time of the first Lead-in Area of the disc)
                         }
 
                         session_no = track.session;
@@ -678,16 +674,16 @@ impl ScsiTargetCdrom {
         let curr_session = sessions
             .iter()
             .rev()
-            .find(|s| s.leadin <= self.audio_pos)
+            .find(|s| s.start <= self.audio_pos)
             .unwrap();
-        if self.audio_pos < curr_session.leadin + LBA_START_SECTOR {
-            // Audio position is in the leadin; skip to the program area
-            self.audio_pos = curr_session.leadin + LBA_START_SECTOR;
+        if self.audio_pos < curr_session.start + LBA_START_SECTOR {
+            // Audio position is in the session pregap; skip to the program
+            self.audio_pos = curr_session.start + LBA_START_SECTOR;
         } else if self.audio_pos >= curr_session.leadout {
             // Audio position is past the leadout; skip to the next session
             let next_session = sessions.get((curr_session.number as usize + 1).saturating_sub(1));
             if let Some(next_session) = next_session {
-                self.audio_pos = next_session.leadin + LBA_START_SECTOR;
+                self.audio_pos = next_session.start + LBA_START_SECTOR;
             } else {
                 // There is no next session; stop the audio
                 self.audio_pos = self.audio_stop;


### PR DESCRIPTION
This PR changes some documentation and variable names to fix misinformation about CD lead-ins.

The lead-in is _not_ the 150 sectors at the start of session; that is the session pre-gap. Even Google's AI gets this wrong.