### PR TITLE
Add the Macintosh 21" Two-Page monitor

### DIFF
--- a/core/src/mac/mod.rs
+++ b/core/src/mac/mod.rs
@@ -499,7 +499,9 @@ impl MacMonitor {
         match self {
             Self::RGB12 => [2, 2, 0, 2],
             Self::HiRes14 => [6, 2, 4, 6],
+            /* RGB15 => [5, 1, 0, 1] according to TN HW30, detected as RGB16 */
             Self::RGB16 => [7, 2, 5, 2],
+            /* RGB19 => [7, 3, 4, 4] according to TN HW30, not detected */
             Self::RGB21 => [0, 0, 0, 0],
             Self::PortraitBW => [1, 1, 1, 0],
             Self::TwoPageBW => [3, 1, 0, 0],

--- a/core/src/mac/mod.rs
+++ b/core/src/mac/mod.rs
@@ -471,6 +471,8 @@ pub enum MacMonitor {
     RGB21,
     /// Macintosh 15" Portrait monitor (640x870, B&W)
     PortraitBW,
+    /// Macintosh 21" Two-Page monitor (1152x870, B&W)
+    TwoPageBW,
 }
 
 impl Display for MacMonitor {
@@ -484,6 +486,7 @@ impl Display for MacMonitor {
                 Self::RGB16 => "Macintosh 16\" RGB monitor",
                 Self::RGB21 => "Macintosh 21\" RGB monitor",
                 Self::PortraitBW => "Macintosh 15\" Portrait monitor",
+                Self::TwoPageBW => "Macintosh 21\" Two-Page monitor",
             },
             self.width(),
             self.height()
@@ -499,6 +502,7 @@ impl MacMonitor {
             Self::RGB16 => [7, 2, 5, 2],
             Self::RGB21 => [0, 0, 0, 0],
             Self::PortraitBW => [1, 1, 1, 0],
+            Self::TwoPageBW => [3, 1, 0, 0],
         }
     }
 
@@ -509,6 +513,7 @@ impl MacMonitor {
             Self::RGB16 => 832,
             Self::RGB21 => 1152,
             Self::PortraitBW => 640,
+            Self::TwoPageBW => 1152,
         }
     }
 
@@ -519,13 +524,14 @@ impl MacMonitor {
             Self::RGB16 => 624,
             Self::RGB21 => 870,
             Self::PortraitBW => 870,
+            Self::TwoPageBW => 870,
         }
     }
 
     pub fn has_color(self) -> bool {
         match self {
             Self::RGB12 | Self::HiRes14 | Self::RGB16 | Self::RGB21 => true,
-            Self::PortraitBW => false,
+            Self::PortraitBW | Self::TwoPageBW => false,
         }
     }
 }


### PR DESCRIPTION
Checked all of the missing fixed resolution monitors from Apple Technical Note HW30.

Only the Two-Page was missing to snow. The two others aren't detected correctly, I'm not even sure they were released.