### PR TITLE
Don’t merge multiple mouse button events in queue

### DIFF
--- a/core/src/mac/adb/mouse.rs
+++ b/core/src/mac/adb/mouse.rs
@@ -90,7 +90,10 @@ impl AdbDevice for AdbMouse {
             0 => {
                 if self.get_srq() {
                     let mut has_button_event = false;
-                    while let Some(event) = self.event_queue.pop_front_if(|event| !has_button_event || event.button.is_none()) {
+                    while let Some(event) = self
+                        .event_queue
+                        .pop_front_if(|event| !has_button_event || event.button.is_none())
+                    {
                         if let Some(btn) = event.button {
                             has_button_event = true;
                             self.button = btn;

--- a/core/src/mac/adb/mouse.rs
+++ b/core/src/mac/adb/mouse.rs
@@ -89,8 +89,10 @@ impl AdbDevice for AdbMouse {
         match reg {
             0 => {
                 if self.get_srq() {
-                    while let Some(event) = self.event_queue.pop_front() {
+                    let mut has_button_event = false;
+                    while let Some(event) = self.event_queue.pop_front_if(|event| !has_button_event || event.button.is_none()) {
                         if let Some(btn) = event.button {
+                            has_button_event = true;
                             self.button = btn;
                         }
                         if let Some(rel_move) = event.rel_movement {


### PR DESCRIPTION
When responding to an ADB `talk` request to the emulated mouse, the code currently iterates any (real) mouse events in the queue, so it can add together multiple relative XY movements into a single response. However, if there are multiple mouse _button_ events in the queue, it also combines these, sending only the latest one.

This logic doesn't make sense for the mouse button. Any time the emulation is unable to poll the mouse faster than the user is able to click it, a mouse DOWN and a mouse UP event will both end up in the queue together, and during the next `talk` only the mouse UP will be processed. The DOWN will be ignored, so the Mac doesn't see this as a click.

Instead, I suggest that we stop iterating the event queue if a second mouse button event is encountered, leaving the remaining events for the next poll.

Fixes #333 