### PR TITLE
Avoid unused variable warning when mmap is disabled

### DIFF
--- a/core/src/mac/scsi/disk_image.rs
+++ b/core/src/mac/scsi/disk_image.rs
@@ -59,6 +59,8 @@ impl FileDiskImage {
 
         #[cfg(not(feature = "mmap"))]
         let disk = {
+            let _ = writable;
+
             use std::fs;
 
             let disk = fs::read(filename)


### PR DESCRIPTION
Affected the Emscripten/Infinite Mac build, but could technically happen on any platform where the mmap feature is disabled.