### PR TITLE
PMMU: implement generational flush on ATC

### DIFF
--- a/core/src/cpu_m68k/cpu.rs
+++ b/core/src/cpu_m68k/cpu.rs
@@ -14,6 +14,7 @@ use thiserror::Error;
 use crate::bus::{Address, Bus, IrqSource};
 use crate::cpu_m68k::fpu::regs::FpuRegisterFile;
 use crate::cpu_m68k::pmmu::regs::PmmuRegisterFile;
+use crate::cpu_m68k::pmmu::translate::atc_generation_default;
 use crate::cpu_m68k::regs::RegisterCACR;
 use crate::cpu_m68k::{M68000_SR_MASK, M68020_CACR_MASK, M68030, M68030_CACR_MASK};
 use crate::tickable::{Tickable, Ticks};
@@ -364,6 +365,11 @@ pub struct CpuM68k<
     pub(in crate::cpu_m68k) pmmu_atc: [Vec<Option<crate::cpu_m68k::pmmu::translate::PmmuAtcEntry>>;
         crate::cpu_m68k::pmmu::translate::PMMU_ATCS],
 
+    /// Current ATC generation. Entries tagged with an older generation have been flushed
+    /// On flush, this is incremented to efficiently invalidate the entire ATC.
+    #[serde(default = "crate::cpu_m68k::pmmu::translate::atc_generation_default")]
+    pub(in crate::cpu_m68k) pmmu_atc_generation: u32,
+
     /// 68020+ I-cache lines
     #[serde(with = "BigArray")]
     icache_lines: [[u8; ICACHE_LINE_SIZE]; ICACHE_LINES],
@@ -418,6 +424,7 @@ where
             systrap_history: VecDeque::with_capacity(Self::HISTORY_SIZE),
             systrap_history_enabled: false,
             pmmu_atc: Default::default(),
+            pmmu_atc_generation: atc_generation_default(),
             icache_lines: core::array::from_fn(|_| Default::default()),
             icache_tags: [ICACHE_TAG_INVALID; ICACHE_LINES],
             restart_regs: None,

--- a/core/src/cpu_m68k/pmmu/translate.rs
+++ b/core/src/cpu_m68k/pmmu/translate.rs
@@ -34,6 +34,11 @@ struct PmmuWalkResult {
     modified: bool,
 }
 
+pub(in crate::cpu_m68k) fn atc_generation_default() -> u32 {
+    // 0 is reserved for unused entries
+    1
+}
+
 /// A resolved Address Translation Cache entry.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub(in crate::cpu_m68k) struct PmmuAtcEntry {
@@ -51,6 +56,10 @@ pub(in crate::cpu_m68k) struct PmmuAtcEntry {
     /// Whether the M bit of the leaf descriptor is already set. When false,
     /// the next write through this entry must RMW the descriptor to set M.
     pub modified: bool,
+    // If < current generation, then this entry has been flushed.
+    // 0 means never used.
+    #[serde(default)]
+    pub generation: u32,
 }
 
 /// Custom (de)serialization for the PMMU ATC tables.
@@ -222,7 +231,28 @@ where
 
     /// Flushes complete ATC
     pub(in crate::cpu_m68k) fn pmmu_cache_invalidate(&mut self) {
-        self.pmmu_atc.iter_mut().for_each(|atc| atc.fill(None));
+        // Incrementing generation invalidates all entries with a lower generation,
+        // making ATC flushes very cheap rather than zeroizing the entire cache.
+        self.pmmu_atc_generation = self.pmmu_atc_generation.wrapping_add(1);
+
+        if self.pmmu_atc_generation == 0 {
+            // Handle wraparound with a full cache purge.
+            self.pmmu_atc.iter_mut().for_each(|atc| atc.fill(None));
+            self.pmmu_atc_generation = 1;
+        }
+    }
+
+    /// Looks an address up in the ATC
+    #[inline(always)]
+    pub(in crate::cpu_m68k) fn pmmu_atc_lookup(
+        &self,
+        atc: usize,
+        key: usize,
+    ) -> Option<PmmuAtcEntry> {
+        match self.pmmu_atc[atc][key] {
+            Some(e) if e.generation == self.pmmu_atc_generation => Some(e),
+            _ => None,
+        }
     }
 
     #[inline(always)]
@@ -509,7 +539,7 @@ where
         let is_mask = Address::MAX.unbounded_shl(32 - self.regs.pmmu.tc.is());
         let page_mask = (1u32 << self.regs.pmmu.tc.ps()) - 1;
         let cache_key = ((vaddr & !is_mask) >> self.regs.pmmu.tc.ps()) as usize;
-        if let Some(entry) = self.pmmu_atc[atc][cache_key] {
+        if let Some(entry) = self.pmmu_atc_lookup(atc, cache_key) {
             if !supervisor && entry.s {
                 self.pmmu_record_atc_fault(vaddr, writing, |psr| {
                     psr.set_supervisor_violation(true);
@@ -544,6 +574,7 @@ where
             s,
             leaf_desc_addr,
             modified,
+            generation: self.pmmu_atc_generation,
         });
         Ok(paddr)
     }

--- a/core/src/cpu_m68k/tests/mod.rs
+++ b/core/src/cpu_m68k/tests/mod.rs
@@ -1,6 +1,7 @@
 mod group2_exceptions;
 mod illegal_exception;
 mod interrupt;
+mod pmmu_atc;
 mod privilege_violation;
 mod privilege_violation_68020;
 mod singlestep;

--- a/core/src/cpu_m68k/tests/pmmu_atc.rs
+++ b/core/src/cpu_m68k/tests/pmmu_atc.rs
@@ -1,0 +1,63 @@
+//! Tests for the PMMU address translation cache
+
+use crate::bus::Address;
+use crate::bus::testbus::Testbus;
+use crate::cpu_m68k::pmmu::translate::{PMMU_ATC_SRP, PmmuAtcEntry};
+use crate::cpu_m68k::{CpuM68030Fpu, M68030_ADDRESS_MASK};
+
+type TestCpu = CpuM68030Fpu<Testbus<Address, u8>>;
+
+const KEY: usize = 4;
+
+fn testcpu() -> TestCpu {
+    let mut cpu = TestCpu::new(Testbus::new(M68030_ADDRESS_MASK));
+    cpu.pmmu_atc.iter_mut().for_each(|t| t.resize(16, None));
+    cpu
+}
+
+fn entry(cpu: &TestCpu, paddr: Address) -> PmmuAtcEntry {
+    PmmuAtcEntry {
+        paddr,
+        wp: false,
+        s: false,
+        leaf_desc_addr: 0x1000,
+        modified: false,
+        generation: cpu.pmmu_atc_generation,
+    }
+}
+
+/// A flush moves the generation on rather than clearing the tables, so stale
+/// entries are left behind but must never be handed out again.
+#[test]
+fn flush_invalidates_by_generation() {
+    let mut cpu = testcpu();
+    let e = entry(&cpu, 0x0020_0000);
+    cpu.pmmu_atc[PMMU_ATC_SRP][KEY] = Some(e);
+
+    assert_eq!(cpu.pmmu_atc_lookup(PMMU_ATC_SRP, KEY), Some(e));
+
+    cpu.pmmu_cache_invalidate();
+    assert_eq!(cpu.pmmu_atc_lookup(PMMU_ATC_SRP, KEY), None);
+    assert!(cpu.pmmu_atc[PMMU_ATC_SRP][KEY].is_some(),);
+
+    // Refilling the slot in the current generation makes it usable again
+    let e2 = entry(&cpu, 0x0040_0000);
+    cpu.pmmu_atc[PMMU_ATC_SRP][KEY] = Some(e2);
+    assert_eq!(cpu.pmmu_atc_lookup(PMMU_ATC_SRP, KEY), Some(e2));
+}
+
+#[test]
+fn generation_wraparound_clears_the_tables() {
+    let mut cpu = testcpu();
+    cpu.pmmu_atc_generation = u32::MAX;
+
+    let e = entry(&cpu, 0x0020_0000);
+    cpu.pmmu_atc[PMMU_ATC_SRP][KEY] = Some(e);
+    assert_eq!(cpu.pmmu_atc_lookup(PMMU_ATC_SRP, KEY), Some(e));
+
+    cpu.pmmu_cache_invalidate();
+
+    assert_eq!(cpu.pmmu_atc_generation, 1);
+    assert_eq!(cpu.pmmu_atc[PMMU_ATC_SRP][KEY], None);
+    assert_eq!(cpu.pmmu_atc_lookup(PMMU_ATC_SRP, KEY), None);
+}


### PR DESCRIPTION
This saves a complete zeroiziation of megabytes of ATC on ATC flush, which happens a LOT (e.g. in SwapMMUMode and A/UX multitasking), instead making a flush operation O(1).

This speeds up the 68030 and 68020+PMMU considerably.

Fixes: #350