### PR TITLE
Fix floppy access when overclocking is enabled

### DIFF
--- a/core/src/emulator/mod.rs
+++ b/core/src/emulator/mod.rs
@@ -203,7 +203,7 @@ dispatch! {
 
     mutable_calls {
         fn set_speed(&mut self, speed: EmulatorSpeed) -> () { bus.set_speed(speed) }
-        fn set_bus_frequency(&mut self, bus_frequency: u64) -> () { bus.set_bus_frequency(bus_frequency) }
+        fn set_base_frequency(&mut self, base_frequency: u64) -> () { bus.set_base_frequency(base_frequency) }
         fn set_audio_provider(&mut self, provider: &mut dyn AudioProvider) -> Result<()> { bus.set_audio_provider(provider) }
 
         fn cpu_tick(&mut self, ticks: Ticks) -> Result<Ticks> { tick(ticks, ()) }
@@ -240,7 +240,7 @@ dispatch! {
 /// An interface that allows sub-components to access emulator state (such as the speed setting)
 pub trait EmuContext {
     fn speed(&self) -> EmulatorSpeed;
-    fn bus_frequency(&self) -> Ticks;
+    fn base_frequency(&self) -> Ticks;
 }
 
 /// Emulator runner
@@ -1219,7 +1219,7 @@ impl Tickable for Emulator {
                     EmulatorCommand::SetSpeed(s) => self.config.set_speed(s),
                     EmulatorCommand::SetOverclock(overclock) => self
                         .config
-                        .set_bus_frequency(overclock.unwrap_or(DEFAULT_BUS_SPEED)),
+                        .set_base_frequency(overclock.unwrap_or(DEFAULT_BUS_SPEED)),
                     EmulatorCommand::ProgKey => self.config.progkey(),
                     EmulatorCommand::WriteRegister(reg, val) => {
                         match reg {

--- a/core/src/mac/compact/bus.rs
+++ b/core/src/mac/compact/bus.rs
@@ -86,7 +86,7 @@ pub struct CompactMacBus<TRenderer: Renderer> {
     /// Emulation speed setting
     pub(crate) speed: EmulatorSpeed,
 
-    bus_frequency: Ticks,
+    base_frequency: Ticks,
 
     /// Last pushed audio sample
     last_audiosample: u8,
@@ -197,7 +197,7 @@ where
 
             overlay: true,
             speed: EmulatorSpeed::Accurate,
-            bus_frequency: DEFAULT_BUS_SPEED,
+            base_frequency: DEFAULT_BUS_SPEED,
             last_audiosample: 0,
             vblank_time: Instant::now(),
             vpa_sync: false,
@@ -517,8 +517,8 @@ where
         self.speed = speed;
     }
 
-    pub fn set_bus_frequency(&mut self, bus_frequency: u64) {
-        self.bus_frequency = bus_frequency;
+    pub fn set_base_frequency(&mut self, base_frequency: u64) {
+        self.base_frequency = base_frequency;
     }
 
     /// Tests for wait states on bus access
@@ -705,7 +705,7 @@ where
     fn tick(&mut self, ticks: Ticks, _: ()) -> Result<Ticks> {
         struct BusEmuContext {
             speed: EmulatorSpeed,
-            bus_frequency: Ticks,
+            base_frequency: Ticks,
         }
 
         impl EmuContext for BusEmuContext {
@@ -713,14 +713,14 @@ where
                 self.speed
             }
 
-            fn bus_frequency(&self) -> Ticks {
-                self.bus_frequency
+            fn base_frequency(&self) -> Ticks {
+                self.base_frequency
             }
         }
 
         let ctx = &BusEmuContext {
             speed: self.speed,
-            bus_frequency: self.bus_frequency,
+            base_frequency: self.base_frequency,
         };
 
         // XXX: run one tick at a time to avoid missing hblanks and vblanks
@@ -730,9 +730,9 @@ where
             self.cycles += ticks;
 
             self.clock_16mhz.add_a_ticks(ticks);
-            let ticks_16mhz = self.clock_16mhz.get_b_ticks(self.bus_frequency);
+            let ticks_16mhz = self.clock_16mhz.get_b_ticks(self.base_frequency);
             self.clock_16mhz
-                .subtract_b_ticks(ticks_16mhz, self.bus_frequency);
+                .subtract_b_ticks(ticks_16mhz, self.base_frequency);
 
             self.eclock += ticks_16mhz;
             while self.eclock >= 10 {

--- a/core/src/mac/compact/bus.rs
+++ b/core/src/mac/compact/bus.rs
@@ -42,6 +42,13 @@ pub struct CompactMacBus<TRenderer: Renderer> {
     /// 16 MHz clock for components that cannot be overclocked (such as VIA and SWIM).
     clock_16mhz: TickConverter<DEFAULT_BUS_SPEED>,
 
+    /// If greater than 0, hold a waitstate until this number of 16 MHz ticks elapse.
+    /// This throttles CPU for components that fail when overclocked (such as SWIM).
+    delay_16mhz: Ticks,
+
+    /// If true, the IWM access delay has been triggered.
+    iwm_delay_trigger: bool,
+
     /// The currently emulated Macintosh model
     model: MacModel,
 
@@ -169,6 +176,8 @@ where
         let mut bus = Self {
             cycles: 0,
             clock_16mhz: Default::default(),
+            delay_16mhz: 0,
+            iwm_delay_trigger: false,
             model,
 
             rom: Vec::from(rom),
@@ -617,6 +626,14 @@ where
     }
 }
 
+fn is_iwm_addr(addr: Address) -> bool {
+    match addr {
+        // IWM
+        0x00DF_E1FF..=0x00DF_FFFF => true,
+        _ => false,
+    }
+}
+
 impl<TRenderer> Bus<Address, Byte> for CompactMacBus<TRenderer>
 where
     TRenderer: Renderer,
@@ -628,6 +645,19 @@ where
     fn read(&mut self, addr: Address) -> BusResult<Byte> {
         if self.in_waitstate(addr) {
             return BusResult::WaitState;
+        }
+
+        if is_iwm_addr(addr) {
+            if self.iwm_delay_trigger {
+                // Reset trigger and allow the access to proceed
+                self.iwm_delay_trigger = false;
+            } else {
+                // Trigger the access delay
+                // FIXME: This should be += 1, but that doesn't work...
+                self.delay_16mhz += 8;
+                self.iwm_delay_trigger = true;
+                return BusResult::WaitState;
+            }
         }
 
         let val = if self.overlay {
@@ -648,6 +678,19 @@ where
     fn write(&mut self, addr: Address, val: Byte) -> BusResult<Byte> {
         if self.in_waitstate(addr) {
             return BusResult::WaitState;
+        }
+
+        if is_iwm_addr(addr) {
+            if self.iwm_delay_trigger {
+                // Reset trigger and allow the access to proceed
+                self.iwm_delay_trigger = false;
+            } else {
+                // Trigger the access delay
+                // FIXME: This should be += 1, but that doesn't work...
+                self.delay_16mhz += 8;
+                self.iwm_delay_trigger = true;
+                return BusResult::WaitState;
+            }
         }
 
         let written = if self.overlay {
@@ -733,6 +776,8 @@ where
             let ticks_16mhz = self.clock_16mhz.get_b_ticks(self.base_frequency);
             self.clock_16mhz
                 .subtract_b_ticks(ticks_16mhz, self.base_frequency);
+
+            self.delay_16mhz = self.delay_16mhz.saturating_sub(ticks_16mhz);
 
             self.eclock += ticks_16mhz;
             while self.eclock >= 10 {

--- a/core/src/mac/compact/bus.rs
+++ b/core/src/mac/compact/bus.rs
@@ -21,7 +21,7 @@ use crate::mac::via::Via;
 use crate::renderer::{
     AUDIO_BUFFER_SAMPLES, AUDIO_CHANNELS, AudioProvider, Renderer, null_audio_sink,
 };
-use crate::tickable::{Tickable, Ticks};
+use crate::tickable::{TickConverter, Tickable, Ticks};
 use crate::types::{Byte, LatchingEvent, MouseEvent};
 use crate::util::take_from_accumulator;
 
@@ -38,6 +38,9 @@ pub const RAM_DIRTY_PAGESIZE: usize = 256;
 #[serde(bound = "")]
 pub struct CompactMacBus<TRenderer: Renderer> {
     cycles: Ticks,
+
+    /// 16 MHz clock for components that cannot be overclocked (such as VIA and SWIM).
+    clock_16mhz: TickConverter<DEFAULT_BUS_SPEED>,
 
     /// The currently emulated Macintosh model
     model: MacModel,
@@ -165,6 +168,7 @@ where
 
         let mut bus = Self {
             cycles: 0,
+            clock_16mhz: Default::default(),
             model,
 
             rom: Vec::from(rom),
@@ -725,13 +729,18 @@ where
 
             self.cycles += ticks;
 
-            self.eclock += ticks;
+            self.clock_16mhz.add_a_ticks(ticks);
+            let ticks_16mhz = self.clock_16mhz.get_b_ticks(self.bus_frequency);
+            self.clock_16mhz
+                .subtract_b_ticks(ticks_16mhz, self.bus_frequency);
+
+            self.eclock += ticks_16mhz;
             while self.eclock >= 10 {
                 // The E Clock is roughly 1/10th of the CPU clock
                 // TODO ticks when VPA is asserted
                 self.eclock -= 10;
 
-                self.via.tick(1, ctx)?;
+                self.via.tick(1, ())?;
             }
 
             // Pixel clock (15.6672 MHz) is roughly 2x CPU speed
@@ -813,7 +822,8 @@ where
             }
 
             self.scsi.tick(ticks, ctx)?;
-            self.swim.tick(ticks, ())?;
+            // FIXME: Running swim at 16mhz doesn't fix floppies failing to boot...
+            self.swim.tick(ticks_16mhz, ())?;
         }
 
         Ok(ticks)

--- a/core/src/mac/compact/bus.rs
+++ b/core/src/mac/compact/bus.rs
@@ -11,7 +11,6 @@ use crate::emulator::{EmuContext, MouseMode};
 use crate::keymap::KeyEvent;
 use crate::mac::MacModel;
 use crate::mac::adb::{AdbEvent, AdbKeyboard, AdbMouse};
-use crate::mac::macii::bus::DEFAULT_BUS_SPEED;
 use crate::mac::rtc::Rtc;
 use crate::mac::scc::{Scc, SccCh};
 use crate::mac::scsi::controller::ScsiController;
@@ -31,8 +30,20 @@ use log::*;
 use num_traits::{FromPrimitive, PrimInt, ToBytes};
 use serde::{Deserialize, Serialize};
 
+/// Mac compact main clock speed
+/// (FIXME: should be 8,000,000? but other parts of the code don't seem to take this into account...)
+pub const DEFAULT_BUS_SPEED: Ticks = 16_000_000;
+
 /// Size of a RAM page in MacBus::ram_dirty
 pub const RAM_DIRTY_PAGESIZE: usize = 256;
+
+/// The minimum number of 16 MHz cycles between IWM register accesses.
+///
+/// This is used to throttle the CPU when overclocking is enabled, preventing
+/// tight polling loops from detecting a timeout prematurely.
+///
+/// 9 appears to be the minimum. If set any lower, it fails. (FIXME: test for compact)
+const IWM_DELAY_CYCLES: Ticks = 9;
 
 #[derive(Serialize, Deserialize)]
 #[serde(bound = "")]
@@ -40,14 +51,11 @@ pub struct CompactMacBus<TRenderer: Renderer> {
     cycles: Ticks,
 
     /// 16 MHz clock for components that cannot be overclocked (such as VIA and SWIM).
+    /// FIXME: should this be 8 MHz on compact?
     clock_16mhz: TickConverter<DEFAULT_BUS_SPEED>,
 
-    /// If greater than 0, hold a waitstate until this number of 16 MHz ticks elapse.
-    /// This throttles CPU for components that fail when overclocked (such as SWIM).
-    delay_16mhz: Ticks,
-
-    /// If true, the IWM access delay has been triggered.
-    iwm_delay_trigger: bool,
+    /// The number of 16 MHz cycles remaining until the IWM can be accessed again.
+    iwm_delay_cycles: Ticks,
 
     /// The currently emulated Macintosh model
     model: MacModel,
@@ -176,8 +184,7 @@ where
         let mut bus = Self {
             cycles: 0,
             clock_16mhz: Default::default(),
-            delay_16mhz: 0,
-            iwm_delay_trigger: false,
+            iwm_delay_cycles: 0,
             model,
 
             rom: Vec::from(rom),
@@ -532,8 +539,8 @@ where
 
     /// Tests for wait states on bus access
     fn in_waitstate(&mut self, addr: Address) -> bool {
-        if self.delay_16mhz > 0 {
-            return true;
+        if is_iwm_addr(addr) {
+            return self.iwm_delay_cycles > 0;
         }
 
         // DTACK (only for RAM region)
@@ -652,16 +659,7 @@ where
         }
 
         if is_iwm_addr(addr) {
-            if self.iwm_delay_trigger {
-                // Reset trigger and allow the access to proceed
-                self.iwm_delay_trigger = false;
-            } else {
-                // Trigger the access delay
-                // FIXME: This should be += 1, but that doesn't work...
-                self.delay_16mhz += 8;
-                self.iwm_delay_trigger = true;
-                return BusResult::WaitState;
-            }
+            self.iwm_delay_cycles += IWM_DELAY_CYCLES;
         }
 
         let val = if self.overlay {
@@ -685,16 +683,7 @@ where
         }
 
         if is_iwm_addr(addr) {
-            if self.iwm_delay_trigger {
-                // Reset trigger and allow the access to proceed
-                self.iwm_delay_trigger = false;
-            } else {
-                // Trigger the access delay
-                // FIXME: This should be += 1, but that doesn't work...
-                self.delay_16mhz += 8;
-                self.iwm_delay_trigger = true;
-                return BusResult::WaitState;
-            }
+            self.iwm_delay_cycles += IWM_DELAY_CYCLES;
         }
 
         let written = if self.overlay {
@@ -781,7 +770,7 @@ where
             self.clock_16mhz
                 .subtract_b_ticks(ticks_16mhz, self.base_frequency);
 
-            self.delay_16mhz = self.delay_16mhz.saturating_sub(ticks_16mhz);
+            self.iwm_delay_cycles = self.iwm_delay_cycles.saturating_sub(ticks_16mhz);
 
             self.eclock += ticks_16mhz;
             while self.eclock >= 10 {
@@ -871,7 +860,6 @@ where
             }
 
             self.scsi.tick(ticks, ctx)?;
-            // FIXME: Running swim at 16mhz doesn't fix floppies failing to boot...
             self.swim.tick(ticks_16mhz, ())?;
         }
 

--- a/core/src/mac/compact/bus.rs
+++ b/core/src/mac/compact/bus.rs
@@ -532,6 +532,10 @@ where
 
     /// Tests for wait states on bus access
     fn in_waitstate(&mut self, addr: Address) -> bool {
+        if self.delay_16mhz > 0 {
+            return true;
+        }
+
         // DTACK (only for RAM region)
         if (0x0000_0000..=0x003F_FFFF).contains(&addr)
             && !self.video.in_blanking_period()

--- a/core/src/mac/compact/bus.rs
+++ b/core/src/mac/compact/bus.rs
@@ -31,8 +31,7 @@ use num_traits::{FromPrimitive, PrimInt, ToBytes};
 use serde::{Deserialize, Serialize};
 
 /// Mac compact main clock speed
-/// (FIXME: should be 8,000,000? but other parts of the code don't seem to take this into account...)
-pub const DEFAULT_BUS_SPEED: Ticks = 16_000_000;
+pub const DEFAULT_BUS_SPEED: Ticks = 8_000_000;
 
 /// Size of a RAM page in MacBus::ram_dirty
 pub const RAM_DIRTY_PAGESIZE: usize = 256;
@@ -50,11 +49,10 @@ const IWM_DELAY_CYCLES: Ticks = 9;
 pub struct CompactMacBus<TRenderer: Renderer> {
     cycles: Ticks,
 
-    /// 16 MHz clock for components that cannot be overclocked (such as VIA and SWIM).
-    /// FIXME: should this be 8 MHz on compact?
-    clock_16mhz: TickConverter<DEFAULT_BUS_SPEED>,
+    /// 8 MHz clock for components that cannot be overclocked (such as VIA and SWIM).
+    clock_8mhz: TickConverter<DEFAULT_BUS_SPEED>,
 
-    /// The number of 16 MHz cycles remaining until the IWM can be accessed again.
+    /// The number of 8 MHz cycles remaining until the IWM can be accessed again.
     iwm_delay_cycles: Ticks,
 
     /// The currently emulated Macintosh model
@@ -183,7 +181,7 @@ where
 
         let mut bus = Self {
             cycles: 0,
-            clock_16mhz: Default::default(),
+            clock_8mhz: Default::default(),
             iwm_delay_cycles: 0,
             model,
 
@@ -765,14 +763,14 @@ where
 
             self.cycles += ticks;
 
-            self.clock_16mhz.add_a_ticks(ticks);
-            let ticks_16mhz = self.clock_16mhz.get_b_ticks(self.base_frequency);
-            self.clock_16mhz
-                .subtract_b_ticks(ticks_16mhz, self.base_frequency);
+            self.clock_8mhz.add_a_ticks(ticks);
+            let ticks_8mhz = self.clock_8mhz.get_b_ticks(self.base_frequency);
+            self.clock_8mhz
+                .subtract_b_ticks(ticks_8mhz, self.base_frequency);
 
-            self.iwm_delay_cycles = self.iwm_delay_cycles.saturating_sub(ticks_16mhz);
+            self.iwm_delay_cycles = self.iwm_delay_cycles.saturating_sub(ticks_8mhz);
 
-            self.eclock += ticks_16mhz;
+            self.eclock += ticks_8mhz;
             while self.eclock >= 10 {
                 // The E Clock is roughly 1/10th of the CPU clock
                 // TODO ticks when VPA is asserted
@@ -860,7 +858,7 @@ where
             }
 
             self.scsi.tick(ticks, ctx)?;
-            self.swim.tick(ticks_16mhz, ())?;
+            self.swim.tick(ticks_8mhz, ())?;
         }
 
         Ok(ticks)

--- a/core/src/mac/macii/bus.rs
+++ b/core/src/mac/macii/bus.rs
@@ -56,6 +56,13 @@ pub struct MacIIBus<TRenderer: Renderer, const AMU: bool> {
     /// 16 MHz clock for components that cannot be overclocked (such as VIA and SWIM).
     clock_16mhz: TickConverter<DEFAULT_BUS_SPEED>,
 
+    /// If greater than 0, hold a waitstate until this number of 16 MHz ticks elapse.
+    /// This throttles CPU for components that fail when overclocked (such as SWIM).
+    delay_16mhz: Ticks,
+
+    /// If true, the IWM access delay has been triggered.
+    iwm_delay_trigger: bool,
+
     /// The currently emulated Macintosh model
     model: MacModel,
 
@@ -218,6 +225,8 @@ where
         let mut bus = Self {
             cycles: 0,
             clock_16mhz: Default::default(),
+            delay_16mhz: 0,
+            iwm_delay_trigger: false,
             model,
 
             rom: Vec::from(rom),
@@ -637,8 +646,7 @@ where
 
     /// Tests for wait states on bus access
     fn in_waitstate(&self, _addr: Address) -> bool {
-        // TODO
-        false
+        self.delay_16mhz > 0
     }
 
     /// Programmer's key pressed
@@ -693,6 +701,19 @@ where
     }
 }
 
+/// Return true if an address accesses the IWM.
+fn is_iwm_addr(addr: Address) -> bool {
+    match addr {
+        // I/O region (repeats)
+        0x5000_0000..=0x51FF_FFFF => match addr & 0x1_FFFF {
+            // IWM/SWIM
+            0x0001_6000..=0x0001_7FFF => true,
+            _ => false,
+        },
+        _ => false,
+    }
+}
+
 impl<TRenderer, const AMU: bool> Bus<Address, Byte> for MacIIBus<TRenderer, AMU>
 where
     TRenderer: Renderer,
@@ -704,6 +725,19 @@ where
     fn read(&mut self, addr: Address) -> BusResult<Byte> {
         if self.in_waitstate(addr) {
             return BusResult::WaitState;
+        }
+
+        if is_iwm_addr(addr) {
+            if self.iwm_delay_trigger {
+                // Reset trigger and allow the access to proceed
+                self.iwm_delay_trigger = false;
+            } else {
+                // Trigger the access delay
+                // FIXME: This should be += 1, but that doesn't work...
+                self.delay_16mhz += 8;
+                self.iwm_delay_trigger = true;
+                return BusResult::WaitState;
+            }
         }
 
         let val = if AMU && self.amu_active {
@@ -734,6 +768,19 @@ where
     fn write(&mut self, addr: Address, val: Byte) -> BusResult<Byte> {
         if self.in_waitstate(addr) {
             return BusResult::WaitState;
+        }
+
+        if is_iwm_addr(addr) {
+            if self.iwm_delay_trigger {
+                // Reset trigger and allow the access to proceed
+                self.iwm_delay_trigger = false;
+            } else {
+                // Trigger the access delay
+                // FIXME: This should be += 1, but that doesn't work...
+                self.delay_16mhz += 8;
+                self.iwm_delay_trigger = true;
+                return BusResult::WaitState;
+            }
         }
 
         let written = if AMU && self.amu_active {
@@ -822,13 +869,15 @@ where
             }
 
             fn base_frequency(&self) -> Ticks {
-                DEFAULT_BUS_SPEED
+                // DEFAULT_BUS_SPEED
+                self.base_frequency
             }
         }
 
         let ctx = &BusEmuContext {
             speed: self.speed,
-            base_frequency: DEFAULT_BUS_SPEED,
+            // base_frequency: DEFAULT_BUS_SPEED,
+            base_frequency: self.base_frequency,
         };
 
         self.cycles += ticks;
@@ -838,8 +887,10 @@ where
         self.clock_16mhz
             .subtract_b_ticks(ticks_16mhz, self.base_frequency);
 
+        self.delay_16mhz = self.delay_16mhz.saturating_sub(ticks_16mhz);
+
         // XXX: just run the bus at 16mhz (this DOES NOT fix floppies)
-        let ticks = ticks_16mhz;
+        // let ticks = ticks_16mhz;
 
         // XXX: forget about 16mhz (this FIXES floppies, but causes other timing issues)
         // let ticks_16mhz = ticks;

--- a/core/src/mac/macii/bus.rs
+++ b/core/src/mac/macii/bus.rs
@@ -822,13 +822,13 @@ where
             }
 
             fn base_frequency(&self) -> Ticks {
-                self.base_frequency
+                DEFAULT_BUS_SPEED
             }
         }
 
         let ctx = &BusEmuContext {
             speed: self.speed,
-            base_frequency: self.base_frequency,
+            base_frequency: DEFAULT_BUS_SPEED,
         };
 
         self.cycles += ticks;
@@ -837,6 +837,12 @@ where
         let ticks_16mhz = self.clock_16mhz.get_b_ticks(self.base_frequency);
         self.clock_16mhz
             .subtract_b_ticks(ticks_16mhz, self.base_frequency);
+
+        // XXX: just run the bus at 16mhz (this DOES NOT fix floppies)
+        let ticks = ticks_16mhz;
+
+        // XXX: forget about 16mhz (this FIXES floppies, but causes other timing issues)
+        // let ticks_16mhz = ticks;
 
         if AMU {
             self.amu_active = self.via2.ddrb.vfc3() && !self.via2.b_out.vfc3();

--- a/core/src/mac/macii/bus.rs
+++ b/core/src/mac/macii/bus.rs
@@ -736,6 +736,9 @@ where
                 // FIXME: This should be += 1, but that doesn't work...
                 self.delay_16mhz += 8;
                 self.iwm_delay_trigger = true;
+                if self.speed == EmulatorSpeed::Accurate {
+                    log::info!("triggering iwm delay for read...");
+                }
                 return BusResult::WaitState;
             }
         }
@@ -779,6 +782,9 @@ where
                 // FIXME: This should be += 1, but that doesn't work...
                 self.delay_16mhz += 8;
                 self.iwm_delay_trigger = true;
+                if self.speed == EmulatorSpeed::Accurate {
+                    log::info!("triggering iwm delay for write...");
+                }
                 return BusResult::WaitState;
             }
         }
@@ -884,6 +890,10 @@ where
         let ticks_16mhz = self.clock_16mhz.get_b_ticks(self.base_frequency);
         self.clock_16mhz
             .subtract_b_ticks(ticks_16mhz, self.base_frequency);
+
+        if self.speed == EmulatorSpeed::Accurate && self.iwm_delay_trigger {
+            log::info!("ticks {}, ticks_16mhz {}", ticks, ticks_16mhz);
+        }
 
         self.delay_16mhz = self.delay_16mhz.saturating_sub(ticks_16mhz);
 

--- a/core/src/mac/macii/bus.rs
+++ b/core/src/mac/macii/bus.rs
@@ -87,7 +87,7 @@ pub struct MacIIBus<TRenderer: Renderer, const AMU: bool> {
     /// Emulation speed setting
     pub(crate) speed: EmulatorSpeed,
 
-    bus_frequency: Ticks,
+    base_frequency: Ticks,
 
     /// Last vblank time (for syncing to video)
     /// Not serializing this because it is only used for determining how long to
@@ -242,7 +242,7 @@ where
             overlay: true,
             amu_active: false,
             speed: EmulatorSpeed::Accurate,
-            bus_frequency: DEFAULT_BUS_SPEED,
+            base_frequency: DEFAULT_BUS_SPEED,
             //last_audiosample: 0,
             vblank_time: Instant::now(),
             vblank_clock: 0,
@@ -631,8 +631,8 @@ where
         self.speed = speed;
     }
 
-    pub fn set_bus_frequency(&mut self, bus_frequency: u64) {
-        self.bus_frequency = bus_frequency;
+    pub fn set_base_frequency(&mut self, base_frequency: u64) {
+        self.base_frequency = base_frequency;
     }
 
     /// Tests for wait states on bus access
@@ -813,7 +813,7 @@ where
     fn tick(&mut self, ticks: Ticks, _: ()) -> Result<Ticks> {
         struct BusEmuContext {
             speed: EmulatorSpeed,
-            bus_frequency: Ticks,
+            base_frequency: Ticks,
         }
 
         impl EmuContext for BusEmuContext {
@@ -821,22 +821,22 @@ where
                 self.speed
             }
 
-            fn bus_frequency(&self) -> Ticks {
-                self.bus_frequency
+            fn base_frequency(&self) -> Ticks {
+                self.base_frequency
             }
         }
 
         let ctx = &BusEmuContext {
             speed: self.speed,
-            bus_frequency: self.bus_frequency,
+            base_frequency: self.base_frequency,
         };
 
         self.cycles += ticks;
 
         self.clock_16mhz.add_a_ticks(ticks);
-        let ticks_16mhz = self.clock_16mhz.get_b_ticks(self.bus_frequency);
+        let ticks_16mhz = self.clock_16mhz.get_b_ticks(self.base_frequency);
         self.clock_16mhz
-            .subtract_b_ticks(ticks_16mhz, self.bus_frequency);
+            .subtract_b_ticks(ticks_16mhz, self.base_frequency);
 
         if AMU {
             self.amu_active = self.via2.ddrb.vfc3() && !self.via2.b_out.vfc3();
@@ -855,8 +855,8 @@ where
 
         // Legacy VBlank interrupt
         self.vblank_clock += ticks;
-        while self.vblank_clock >= ctx.bus_frequency / 60 {
-            self.vblank_clock -= ctx.bus_frequency / 60;
+        while self.vblank_clock >= ctx.base_frequency / 60 {
+            self.vblank_clock -= ctx.base_frequency / 60;
 
             self.via1.ifr.set_vblank(true);
 
@@ -889,8 +889,8 @@ where
         }
 
         self.asc_clock += ticks;
-        while self.asc_clock >= ctx.bus_frequency / self.asc.sample_rate() {
-            self.asc_clock -= ctx.bus_frequency / self.asc.sample_rate();
+        while self.asc_clock >= ctx.base_frequency / self.asc.sample_rate() {
+            self.asc_clock -= ctx.base_frequency / self.asc.sample_rate();
 
             self.asc.tick(self.speed == EmulatorSpeed::Accurate)?;
         }

--- a/core/src/mac/macii/bus.rs
+++ b/core/src/mac/macii/bus.rs
@@ -34,6 +34,14 @@ use serde::{Deserialize, Serialize};
 /// Macintosh II main clock speed
 pub const DEFAULT_BUS_SPEED: Ticks = 16_000_000;
 
+/// The minimum number of 16 MHz cycles between IWM register accesses.
+///
+/// This is used to throttle the CPU when overclocking is enabled, preventing
+/// tight polling loops from detecting a timeout prematurely.
+///
+/// 9 appears to be the minimum. If set any lower, it fails.
+const IWM_DELAY_CYCLES: Ticks = 9;
+
 /// Size of a RAM page in MacBus::ram_dirty
 pub const RAM_DIRTY_PAGESIZE: usize = 256;
 
@@ -56,12 +64,8 @@ pub struct MacIIBus<TRenderer: Renderer, const AMU: bool> {
     /// 16 MHz clock for components that cannot be overclocked (such as VIA and SWIM).
     clock_16mhz: TickConverter<DEFAULT_BUS_SPEED>,
 
-    /// If greater than 0, hold a waitstate until this number of 16 MHz ticks elapse.
-    /// This throttles CPU for components that fail when overclocked (such as SWIM).
-    delay_16mhz: Ticks,
-
-    /// If true, the IWM access delay has been triggered.
-    iwm_delay_trigger: bool,
+    /// The number of 16 MHz cycles remaining until the IWM can be accessed again.
+    iwm_delay_cycles: Ticks,
 
     /// The currently emulated Macintosh model
     model: MacModel,
@@ -225,8 +229,7 @@ where
         let mut bus = Self {
             cycles: 0,
             clock_16mhz: Default::default(),
-            delay_16mhz: 0,
-            iwm_delay_trigger: false,
+            iwm_delay_cycles: 0,
             model,
 
             rom: Vec::from(rom),
@@ -645,8 +648,12 @@ where
     }
 
     /// Tests for wait states on bus access
-    fn in_waitstate(&self, _addr: Address) -> bool {
-        self.delay_16mhz > 0
+    fn in_waitstate(&self, addr: Address) -> bool {
+        if is_iwm_addr(addr) {
+            return self.iwm_delay_cycles > 0;
+        }
+
+        false
     }
 
     /// Programmer's key pressed
@@ -728,19 +735,7 @@ where
         }
 
         if is_iwm_addr(addr) {
-            if self.iwm_delay_trigger {
-                // Reset trigger and allow the access to proceed
-                self.iwm_delay_trigger = false;
-            } else {
-                // Trigger the access delay
-                // FIXME: This should be += 1, but that doesn't work...
-                self.delay_16mhz += 8;
-                self.iwm_delay_trigger = true;
-                if self.speed == EmulatorSpeed::Accurate {
-                    log::info!("triggering iwm delay for read...");
-                }
-                return BusResult::WaitState;
-            }
+            self.iwm_delay_cycles += IWM_DELAY_CYCLES;
         }
 
         let val = if AMU && self.amu_active {
@@ -774,19 +769,7 @@ where
         }
 
         if is_iwm_addr(addr) {
-            if self.iwm_delay_trigger {
-                // Reset trigger and allow the access to proceed
-                self.iwm_delay_trigger = false;
-            } else {
-                // Trigger the access delay
-                // FIXME: This should be += 1, but that doesn't work...
-                self.delay_16mhz += 8;
-                self.iwm_delay_trigger = true;
-                if self.speed == EmulatorSpeed::Accurate {
-                    log::info!("triggering iwm delay for write...");
-                }
-                return BusResult::WaitState;
-            }
+            self.iwm_delay_cycles += IWM_DELAY_CYCLES;
         }
 
         let written = if AMU && self.amu_active {
@@ -891,11 +874,7 @@ where
         self.clock_16mhz
             .subtract_b_ticks(ticks_16mhz, self.base_frequency);
 
-        if self.speed == EmulatorSpeed::Accurate && self.iwm_delay_trigger {
-            log::info!("ticks {}, ticks_16mhz {}", ticks, ticks_16mhz);
-        }
-
-        self.delay_16mhz = self.delay_16mhz.saturating_sub(ticks_16mhz);
+        self.iwm_delay_cycles = self.iwm_delay_cycles.saturating_sub(ticks_16mhz);
 
         if AMU {
             self.amu_active = self.via2.ddrb.vfc3() && !self.via2.b_out.vfc3();
@@ -975,7 +954,6 @@ where
         self.via2.ifr.set_scsi_drq(self.scsi.get_drq());
 
         self.swim.intdrive = self.via1.a_out.drivesel();
-        // FIXME: Running swim at 16mhz doesn't fix floppies failing to boot...
         self.swim.tick(ticks_16mhz, ())?;
 
         Ok(1)

--- a/core/src/mac/macii/bus.rs
+++ b/core/src/mac/macii/bus.rs
@@ -22,7 +22,7 @@ use crate::mac::{MacModel, MacMonitor, NubusCardConfig, NubusDeviceKind};
 use crate::renderer::{
     AUDIO_BUFFER_SAMPLES, AUDIO_CHANNELS, AudioProvider, Renderer, null_audio_sink,
 };
-use crate::tickable::{Tickable, Ticks};
+use crate::tickable::{TickConverter, Tickable, Ticks};
 use crate::types::{Byte, LatchingEvent, MouseEvent};
 
 use anyhow::Result;
@@ -52,6 +52,9 @@ const RAMSZ_16M: u8 = 3;
 #[serde(bound = "")]
 pub struct MacIIBus<TRenderer: Renderer, const AMU: bool> {
     cycles: Ticks,
+
+    /// 16 MHz clock for components that cannot be overclocked (such as VIA and SWIM).
+    clock_16mhz: TickConverter<DEFAULT_BUS_SPEED>,
 
     /// The currently emulated Macintosh model
     model: MacModel,
@@ -214,6 +217,7 @@ where
 
         let mut bus = Self {
             cycles: 0,
+            clock_16mhz: Default::default(),
             model,
 
             rom: Vec::from(rom),
@@ -829,18 +833,23 @@ where
 
         self.cycles += ticks;
 
+        self.clock_16mhz.add_a_ticks(ticks);
+        let ticks_16mhz = self.clock_16mhz.get_b_ticks(self.bus_frequency);
+        self.clock_16mhz
+            .subtract_b_ticks(ticks_16mhz, self.bus_frequency);
+
         if AMU {
             self.amu_active = self.via2.ddrb.vfc3() && !self.via2.b_out.vfc3();
         }
 
         // The Mac II generates the VIA clock through some dividers on the logic board.
         // This same logic generates wait states when the VIAs are accessed.
-        self.via_clock += ticks;
+        self.via_clock += ticks_16mhz;
         while self.via_clock >= 20 {
             // TODO VIA wait states
             self.via_clock -= 20;
 
-            self.via1.tick(1, ctx)?;
+            self.via1.tick(1, ())?;
             self.via2.tick(1, ())?;
         }
 
@@ -907,7 +916,8 @@ where
         self.via2.ifr.set_scsi_drq(self.scsi.get_drq());
 
         self.swim.intdrive = self.via1.a_out.drivesel();
-        self.swim.tick(ticks, ())?;
+        // FIXME: Running swim at 16mhz doesn't fix floppies failing to boot...
+        self.swim.tick(ticks_16mhz, ())?;
 
         Ok(1)
     }

--- a/core/src/mac/macii/bus.rs
+++ b/core/src/mac/macii/bus.rs
@@ -869,14 +869,12 @@ where
             }
 
             fn base_frequency(&self) -> Ticks {
-                // DEFAULT_BUS_SPEED
                 self.base_frequency
             }
         }
 
         let ctx = &BusEmuContext {
             speed: self.speed,
-            // base_frequency: DEFAULT_BUS_SPEED,
             base_frequency: self.base_frequency,
         };
 
@@ -888,12 +886,6 @@ where
             .subtract_b_ticks(ticks_16mhz, self.base_frequency);
 
         self.delay_16mhz = self.delay_16mhz.saturating_sub(ticks_16mhz);
-
-        // XXX: just run the bus at 16mhz (this DOES NOT fix floppies)
-        // let ticks = ticks_16mhz;
-
-        // XXX: forget about 16mhz (this FIXES floppies, but causes other timing issues)
-        // let ticks_16mhz = ticks;
 
         if AMU {
             self.amu_active = self.via2.ddrb.vfc3() && !self.via2.b_out.vfc3();

--- a/core/src/mac/nubus/mdc12.rs
+++ b/core/src/mac/nubus/mdc12.rs
@@ -390,10 +390,10 @@ where
 {
     fn tick(&mut self, ticks: Ticks, ctx: &dyn EmuContext) -> Result<Ticks> {
         self.vblank_ticks += ticks;
-        if self.vblank_ticks >= ctx.bus_frequency() / 60 {
+        if self.vblank_ticks >= ctx.base_frequency() / 60 {
             self.render()?;
 
-            self.vblank_ticks -= ctx.bus_frequency() / 60;
+            self.vblank_ticks -= ctx.base_frequency() / 60;
             if self.vblank_enable {
                 self.vblank_irq = true;
             }

--- a/core/src/mac/nubus/se30video.rs
+++ b/core/src/mac/nubus/se30video.rs
@@ -146,10 +146,10 @@ where
         if !self.vblank_enable {
             self.vblank_irq = false;
         }
-        if self.vblank_ticks >= ctx.bus_frequency() / 60 {
+        if self.vblank_ticks >= ctx.base_frequency() / 60 {
             self.render()?;
 
-            self.vblank_ticks -= ctx.bus_frequency() / 60;
+            self.vblank_ticks -= ctx.base_frequency() / 60;
             if self.vblank_enable {
                 self.vblank_irq = true;
             }

--- a/core/src/mac/nubus/toby.rs
+++ b/core/src/mac/nubus/toby.rs
@@ -260,14 +260,14 @@ where
 {
     fn tick(&mut self, ticks: Ticks, ctx: &dyn EmuContext) -> Result<Ticks> {
         self.vblank_ticks += ticks;
-        if self.vblank_ticks >= ctx.bus_frequency() / 60 {
+        if self.vblank_ticks >= ctx.base_frequency() / 60 {
             self.render()?;
-            self.vblank_ticks -= ctx.bus_frequency() / 60;
+            self.vblank_ticks -= ctx.base_frequency() / 60;
             if self.vblank_enable {
                 self.vblank_irq = true;
             }
         }
-        self.in_vblank = self.vblank_ticks >= ctx.bus_frequency() / 60 * 480 / 525;
+        self.in_vblank = self.vblank_ticks >= ctx.base_frequency() / 60 * 480 / 525;
         Ok(ticks)
     }
 }

--- a/core/src/mac/portable/bus.rs
+++ b/core/src/mac/portable/bus.rs
@@ -41,6 +41,13 @@ pub struct MacPortableBus<TRenderer: Renderer> {
     /// 16 MHz clock for components that cannot be overclocked (such as VIA and SWIM).
     clock_16mhz: TickConverter<DEFAULT_BUS_SPEED>,
 
+    /// If greater than 0, hold a waitstate until this number of 16 MHz ticks elapse.
+    /// This throttles CPU for components that fail when overclocked (such as SWIM).
+    delay_16mhz: Ticks,
+
+    /// If true, the SWIM access delay has been triggered.
+    swim_delay_trigger: bool,
+
     /// The currently emulated Macintosh model
     model: MacModel,
 
@@ -140,6 +147,8 @@ where
         let mut bus = Self {
             cycles: 0,
             clock_16mhz: Default::default(),
+            delay_16mhz: 0,
+            swim_delay_trigger: false,
             model,
 
             rom_mask: rom.len() - 1,
@@ -514,6 +523,14 @@ where
     }
 }
 
+fn is_swim_addr(addr: Address) -> bool {
+    match addr {
+        // SWIM
+        0x00F6_0000..=0x00F6_FFFF => true,
+        _ => false,
+    }
+}
+
 impl<TRenderer> Bus<Address, Byte> for MacPortableBus<TRenderer>
 where
     TRenderer: Renderer,
@@ -521,6 +538,19 @@ where
     fn read(&mut self, addr: Address) -> BusResult<Byte> {
         if self.in_waitstate(addr) {
             return BusResult::WaitState;
+        }
+
+        if is_swim_addr(addr) {
+            if self.swim_delay_trigger {
+                // Reset trigger and allow the access to proceed
+                self.swim_delay_trigger = false;
+            } else {
+                // Trigger the access delay
+                // FIXME: This should be += 1, but that doesn't work...
+                self.delay_16mhz += 16;
+                self.swim_delay_trigger = true;
+                return BusResult::WaitState;
+            }
         }
 
         let val = if self.overlay {
@@ -540,6 +570,19 @@ where
     fn write(&mut self, addr: Address, val: Byte) -> BusResult<Byte> {
         if self.in_waitstate(addr) {
             return BusResult::WaitState;
+        }
+
+        if is_swim_addr(addr) {
+            if self.swim_delay_trigger {
+                // Reset trigger and allow the access to proceed
+                self.swim_delay_trigger = false;
+            } else {
+                // Trigger the access delay
+                // FIXME: This should be += 1, but that doesn't work...
+                self.delay_16mhz += 16;
+                self.swim_delay_trigger = true;
+                return BusResult::WaitState;
+            }
         }
 
         let written = if self.overlay {
@@ -629,6 +672,8 @@ where
         let ticks_16mhz = self.clock_16mhz.get_b_ticks(self.base_frequency);
         self.clock_16mhz
             .subtract_b_ticks(ticks_16mhz, self.base_frequency);
+
+        self.delay_16mhz = self.delay_16mhz.saturating_sub(ticks_16mhz);
 
         self.via_clock += ticks_16mhz;
         while self.via_clock >= 20 {

--- a/core/src/mac/portable/bus.rs
+++ b/core/src/mac/portable/bus.rs
@@ -21,7 +21,7 @@ use crate::mac::swim::Swim;
 use crate::renderer::{
     AUDIO_BUFFER_SAMPLES, AUDIO_CHANNELS, AudioProvider, Renderer, null_audio_sink,
 };
-use crate::tickable::{Tickable, Ticks};
+use crate::tickable::{TickConverter, Tickable, Ticks};
 use crate::types::{Byte, LatchingEvent, MouseEvent};
 
 use anyhow::Result;
@@ -37,6 +37,9 @@ pub const RAM_DIRTY_PAGESIZE: usize = 256;
 #[serde(bound = "")]
 pub struct MacPortableBus<TRenderer: Renderer> {
     cycles: Ticks,
+
+    /// 16 MHz clock for components that cannot be overclocked (such as VIA and SWIM).
+    clock_16mhz: TickConverter<DEFAULT_BUS_SPEED>,
 
     /// The currently emulated Macintosh model
     model: MacModel,
@@ -136,6 +139,7 @@ where
 
         let mut bus = Self {
             cycles: 0,
+            clock_16mhz: Default::default(),
             model,
 
             rom_mask: rom.len() - 1,
@@ -621,12 +625,17 @@ where
 
         self.cycles += ticks;
 
-        self.via_clock += ticks;
+        self.clock_16mhz.add_a_ticks(ticks);
+        let ticks_16mhz = self.clock_16mhz.get_b_ticks(self.bus_frequency);
+        self.clock_16mhz
+            .subtract_b_ticks(ticks_16mhz, self.bus_frequency);
+
+        self.via_clock += ticks_16mhz;
         while self.via_clock >= 20 {
             // TODO VIA wait states
             self.via_clock -= 20;
 
-            self.via.tick(1, ctx)?;
+            self.via.tick(1, ())?;
         }
 
         self.video.tick(ticks, ctx)?;
@@ -658,7 +667,8 @@ where
         }
 
         self.swim.intdrive = self.via.b_out.drivesel();
-        self.swim.tick(ticks, ())?;
+        // FIXME: Running swim at 16mhz doesn't fix floppies failing to boot...
+        self.swim.tick(ticks_16mhz, ())?;
 
         Ok(ticks)
     }

--- a/core/src/mac/portable/bus.rs
+++ b/core/src/mac/portable/bus.rs
@@ -495,6 +495,10 @@ where
 
     /// Tests for wait states on bus access
     fn in_waitstate(&mut self, addr: Address) -> bool {
+        if self.delay_16mhz > 0 {
+            return true;
+        }
+
         match addr {
             0x0000_0000..=0x009F_FFFF => self.normandy.waitstate(addr),
             _ => false,
@@ -547,7 +551,7 @@ where
             } else {
                 // Trigger the access delay
                 // FIXME: This should be += 1, but that doesn't work...
-                self.delay_16mhz += 16;
+                self.delay_16mhz += 8;
                 self.swim_delay_trigger = true;
                 return BusResult::WaitState;
             }
@@ -579,7 +583,7 @@ where
             } else {
                 // Trigger the access delay
                 // FIXME: This should be += 1, but that doesn't work...
-                self.delay_16mhz += 16;
+                self.delay_16mhz += 8;
                 self.swim_delay_trigger = true;
                 return BusResult::WaitState;
             }

--- a/core/src/mac/portable/bus.rs
+++ b/core/src/mac/portable/bus.rs
@@ -69,7 +69,7 @@ pub struct MacPortableBus<TRenderer: Renderer> {
     /// Emulation speed setting
     pub(crate) speed: EmulatorSpeed,
 
-    bus_frequency: Ticks,
+    base_frequency: Ticks,
 
     /// Last vblank time (for syncing to video)
     /// Not serializing this because it is only used for determining how long to
@@ -159,7 +159,7 @@ where
 
             overlay: true,
             speed: EmulatorSpeed::Accurate,
-            bus_frequency: DEFAULT_BUS_SPEED,
+            base_frequency: DEFAULT_BUS_SPEED,
             vblank_time: Instant::now(),
             vblank_clock: 0,
             progkey_pressed: LatchingEvent::default(),
@@ -476,8 +476,8 @@ where
         self.speed = speed;
     }
 
-    pub fn set_bus_frequency(&mut self, bus_frequency: u64) {
-        self.bus_frequency = bus_frequency;
+    pub fn set_base_frequency(&mut self, base_frequency: u64) {
+        self.base_frequency = base_frequency;
     }
 
     pub fn set_mouse_mode(&mut self, mode: MouseMode) {
@@ -605,7 +605,7 @@ where
     fn tick(&mut self, ticks: Ticks, _: ()) -> Result<Ticks> {
         struct BusEmuContext {
             speed: EmulatorSpeed,
-            bus_frequency: Ticks,
+            base_frequency: Ticks,
         }
 
         impl EmuContext for BusEmuContext {
@@ -613,22 +613,22 @@ where
                 self.speed
             }
 
-            fn bus_frequency(&self) -> Ticks {
-                self.bus_frequency
+            fn base_frequency(&self) -> Ticks {
+                self.base_frequency
             }
         }
 
         let ctx = &BusEmuContext {
             speed: self.speed,
-            bus_frequency: self.bus_frequency,
+            base_frequency: self.base_frequency,
         };
 
         self.cycles += ticks;
 
         self.clock_16mhz.add_a_ticks(ticks);
-        let ticks_16mhz = self.clock_16mhz.get_b_ticks(self.bus_frequency);
+        let ticks_16mhz = self.clock_16mhz.get_b_ticks(self.base_frequency);
         self.clock_16mhz
-            .subtract_b_ticks(ticks_16mhz, self.bus_frequency);
+            .subtract_b_ticks(ticks_16mhz, self.base_frequency);
 
         self.via_clock += ticks_16mhz;
         while self.via_clock >= 20 {
@@ -642,8 +642,8 @@ where
 
         // Legacy VBlank interrupt
         self.vblank_clock += ticks;
-        while self.vblank_clock >= self.bus_frequency / 60 {
-            self.vblank_clock -= self.bus_frequency / 60;
+        while self.vblank_clock >= self.base_frequency / 60 {
+            self.vblank_clock -= self.base_frequency / 60;
             self.via.ifr.set_vblank(true);
 
             if self.speed == EmulatorSpeed::Video {
@@ -660,8 +660,8 @@ where
         }
 
         self.asc_clock += ticks;
-        while self.asc_clock >= self.bus_frequency / self.asc.sample_rate() {
-            self.asc_clock -= self.bus_frequency / self.asc.sample_rate();
+        while self.asc_clock >= self.base_frequency / self.asc.sample_rate() {
+            self.asc_clock -= self.base_frequency / self.asc.sample_rate();
 
             self.asc.tick(self.speed == EmulatorSpeed::Accurate)?;
         }

--- a/core/src/mac/portable/bus.rs
+++ b/core/src/mac/portable/bus.rs
@@ -13,7 +13,6 @@ use crate::keymap::KeyEvent;
 use crate::mac::MacModel;
 use crate::mac::adb::{AdbEvent, AdbKeyboard, AdbMouse};
 use crate::mac::asc::Asc;
-use crate::mac::macii::bus::DEFAULT_BUS_SPEED;
 use crate::mac::rtc::Rtc;
 use crate::mac::scc::Scc;
 use crate::mac::scsi::controller::ScsiController;
@@ -30,8 +29,19 @@ use log::*;
 use num_traits::{FromPrimitive, PrimInt, ToBytes};
 use serde::{Deserialize, Serialize};
 
+/// Mac portable main clock speed
+pub const DEFAULT_BUS_SPEED: Ticks = 16_000_000;
+
 /// Size of a RAM page in MacBus::ram_dirty
 pub const RAM_DIRTY_PAGESIZE: usize = 256;
+
+/// The minimum number of 16 MHz cycles between SWIM register accesses.
+///
+/// This is used to throttle the CPU when overclocking is enabled, preventing
+/// tight polling loops from detecting a timeout prematurely.
+///
+/// 9 appears to be the minimum. If set any lower, it fails. (FIXME: test for portable)
+const SWIM_DELAY_CYCLES: Ticks = 9;
 
 #[derive(Serialize, Deserialize)]
 #[serde(bound = "")]
@@ -41,12 +51,8 @@ pub struct MacPortableBus<TRenderer: Renderer> {
     /// 16 MHz clock for components that cannot be overclocked (such as VIA and SWIM).
     clock_16mhz: TickConverter<DEFAULT_BUS_SPEED>,
 
-    /// If greater than 0, hold a waitstate until this number of 16 MHz ticks elapse.
-    /// This throttles CPU for components that fail when overclocked (such as SWIM).
-    delay_16mhz: Ticks,
-
-    /// If true, the SWIM access delay has been triggered.
-    swim_delay_trigger: bool,
+    /// The number of 16 MHz cycles remaining until the SWIM can be accessed again.
+    swim_delay_cycles: Ticks,
 
     /// The currently emulated Macintosh model
     model: MacModel,
@@ -147,8 +153,7 @@ where
         let mut bus = Self {
             cycles: 0,
             clock_16mhz: Default::default(),
-            delay_16mhz: 0,
-            swim_delay_trigger: false,
+            swim_delay_cycles: 0,
             model,
 
             rom_mask: rom.len() - 1,
@@ -495,8 +500,8 @@ where
 
     /// Tests for wait states on bus access
     fn in_waitstate(&mut self, addr: Address) -> bool {
-        if self.delay_16mhz > 0 {
-            return true;
+        if is_swim_addr(addr) {
+            return self.swim_delay_cycles > 0;
         }
 
         match addr {
@@ -545,16 +550,7 @@ where
         }
 
         if is_swim_addr(addr) {
-            if self.swim_delay_trigger {
-                // Reset trigger and allow the access to proceed
-                self.swim_delay_trigger = false;
-            } else {
-                // Trigger the access delay
-                // FIXME: This should be += 1, but that doesn't work...
-                self.delay_16mhz += 8;
-                self.swim_delay_trigger = true;
-                return BusResult::WaitState;
-            }
+            self.swim_delay_cycles += SWIM_DELAY_CYCLES;
         }
 
         let val = if self.overlay {
@@ -577,16 +573,7 @@ where
         }
 
         if is_swim_addr(addr) {
-            if self.swim_delay_trigger {
-                // Reset trigger and allow the access to proceed
-                self.swim_delay_trigger = false;
-            } else {
-                // Trigger the access delay
-                // FIXME: This should be += 1, but that doesn't work...
-                self.delay_16mhz += 8;
-                self.swim_delay_trigger = true;
-                return BusResult::WaitState;
-            }
+            self.swim_delay_cycles += SWIM_DELAY_CYCLES;
         }
 
         let written = if self.overlay {
@@ -677,7 +664,7 @@ where
         self.clock_16mhz
             .subtract_b_ticks(ticks_16mhz, self.base_frequency);
 
-        self.delay_16mhz = self.delay_16mhz.saturating_sub(ticks_16mhz);
+        self.swim_delay_cycles = self.swim_delay_cycles.saturating_sub(ticks_16mhz);
 
         self.via_clock += ticks_16mhz;
         while self.via_clock >= 20 {
@@ -716,7 +703,6 @@ where
         }
 
         self.swim.intdrive = self.via.b_out.drivesel();
-        // FIXME: Running swim at 16mhz doesn't fix floppies failing to boot...
         self.swim.tick(ticks_16mhz, ())?;
 
         Ok(ticks)

--- a/core/src/mac/portable/via.rs
+++ b/core/src/mac/portable/via.rs
@@ -5,8 +5,6 @@ use crate::bus::BusMember;
 use crate::debuggable::DebuggableProperty;
 use crate::debuggable::DebuggablePropertyValue;
 use crate::debuggable::{Debuggable, DebuggableProperties};
-use crate::emulator::EmuContext;
-use crate::tickable::TickConverter;
 use crate::tickable::{Tickable, Ticks};
 use crate::types::{Byte, Field16};
 use crate::{dbgprop_bool, dbgprop_byte_bin, dbgprop_group, dbgprop_udec, dbgprop_word};
@@ -17,12 +15,6 @@ use serde::{Deserialize, Serialize};
 /// Counter at which to trigger the one-second interrupt
 /// TODO
 const ONESEC_TICKS: Ticks = 783360;
-
-/// The frequency at which to run the VIA.
-///
-/// Since the VIA is used as a timer, it is important to run at a consistent
-/// speed regardless of CPU/bus frequency.
-const VIA_FREQUENCY: Ticks = 16_000_000;
 
 bitfield! {
     /// VIA Register A
@@ -124,8 +116,6 @@ pub struct Via {
 
     pub t1cnt: Field16,
     pub t1latch: Field16,
-
-    bus_tick_converter: TickConverter<VIA_FREQUENCY>,
 }
 
 impl Via {
@@ -151,8 +141,6 @@ impl Via {
             t1_enable: false,
 
             onesec: 0,
-
-            bus_tick_converter: Default::default(),
         }
     }
 
@@ -341,21 +329,8 @@ impl BusMember<Address> for Via {
     }
 }
 
-impl Tickable<&dyn EmuContext> for Via {
-    fn tick(&mut self, ticks: Ticks, ctx: &dyn EmuContext) -> Result<Ticks> {
-        self.bus_tick_converter.add_a_ticks(ticks);
-        let via_ticks = self.bus_tick_converter.get_b_ticks(ctx.bus_frequency());
-        if via_ticks > 0 {
-            self.tick_16mhz(via_ticks)?;
-            self.bus_tick_converter
-                .subtract_b_ticks(via_ticks, ctx.bus_frequency());
-        }
-        Ok(ticks)
-    }
-}
-
-impl Via {
-    fn tick_16mhz(&mut self, ticks: Ticks) -> Result<Ticks> {
+impl Tickable for Via {
+    fn tick(&mut self, ticks: Ticks, _: ()) -> Result<Ticks> {
         self.onesec += ticks;
 
         if self.onesec >= ONESEC_TICKS {

--- a/core/src/mac/portable/video.rs
+++ b/core/src/mac/portable/video.rs
@@ -73,7 +73,7 @@ where
     T: Renderer,
 {
     fn tick(&mut self, ticks: Ticks, ctx: &dyn EmuContext) -> Result<Ticks> {
-        let frametime: Ticks = ctx.bus_frequency() / 60;
+        let frametime: Ticks = ctx.base_frequency() / 60;
 
         self.vblank_ticks += ticks;
         while self.vblank_ticks > frametime {

--- a/core/src/mac/scsi/cdrom/mod.rs
+++ b/core/src/mac/scsi/cdrom/mod.rs
@@ -1643,8 +1643,8 @@ impl ScsiTarget for ScsiTargetCdrom {
                 None => {
                     // Real audio is disabled. Advance the audio position by counting bus ticks.
                     self.audio_clock += ticks;
-                    if self.audio_clock >= ctx.bus_frequency() / AUDIO_SECTORS_PER_SEC as u64 {
-                        self.audio_clock -= ctx.bus_frequency() / AUDIO_SECTORS_PER_SEC as u64;
+                    if self.audio_clock >= ctx.base_frequency() / AUDIO_SECTORS_PER_SEC as u64 {
+                        self.audio_clock -= ctx.base_frequency() / AUDIO_SECTORS_PER_SEC as u64;
 
                         self.audio_pos += 1;
                         self.resolve_audio_pos();

--- a/core/src/mac/via.rs
+++ b/core/src/mac/via.rs
@@ -1,9 +1,8 @@
 use crate::bus::{Address, BusMember};
 use crate::debuggable::Debuggable;
-use crate::emulator::EmuContext;
 use crate::mac::pluskbd::PlusKeyboard;
 use crate::mac::rtc::Rtc;
-use crate::tickable::{TickConverter, Tickable, Ticks};
+use crate::tickable::{Tickable, Ticks};
 use crate::types::{Byte, Field16};
 
 use anyhow::Result;
@@ -12,12 +11,6 @@ use serde::{Deserialize, Serialize};
 
 use super::MacModel;
 use super::adb::AdbTransceiver;
-
-/// The frequency at which to run the VIA.
-///
-/// Since the VIA is used as a timer, it is important to run at a consistent
-/// speed regardless of CPU/bus frequency.
-const VIA_FREQUENCY: Ticks = 16_000_000;
 
 /// Counter at which to trigger the one second interrupt
 /// (counted on the E Clock)
@@ -262,8 +255,6 @@ pub struct Via {
     pub(crate) rtc: Rtc,
 
     pub(crate) adb: AdbTransceiver,
-
-    bus_tick_converter: TickConverter<VIA_FREQUENCY>,
 }
 
 impl Via {
@@ -300,8 +291,6 @@ impl Via {
             keyboard: PlusKeyboard::default(),
             rtc: Rtc::default(),
             adb: AdbTransceiver::default(),
-
-            bus_tick_converter: Default::default(),
         }
     }
 }
@@ -534,21 +523,8 @@ impl BusMember<Address> for Via {
     }
 }
 
-impl Tickable<&dyn EmuContext> for Via {
-    fn tick(&mut self, ticks: Ticks, ctx: &dyn EmuContext) -> Result<Ticks> {
-        self.bus_tick_converter.add_a_ticks(ticks);
-        let via_ticks = self.bus_tick_converter.get_b_ticks(ctx.bus_frequency());
-        if via_ticks > 0 {
-            self.tick_16mhz(via_ticks)?;
-            self.bus_tick_converter
-                .subtract_b_ticks(via_ticks, ctx.bus_frequency());
-        }
-        Ok(ticks)
-    }
-}
-
-impl Via {
-    fn tick_16mhz(&mut self, ticks: Ticks) -> Result<Ticks> {
+impl Tickable for Via {
+    fn tick(&mut self, ticks: Ticks, _: ()) -> Result<Ticks> {
         // This is ticked on the E Clock
         self.onesec += ticks;
 


### PR DESCRIPTION
This PR makes the SWIM/IWM component run at  native speed regardless of overclocking, fixing floppy access when overclocking is enabled.